### PR TITLE
Add common tiff files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 Libraries/gnustep/gnustep-base-1.26.0*
 Libraries/gnustep/gnustep-gui-0.25.0*
+Libraries/gnustep/common_*.tiff
 *.emacs.desktop*
 *.app
 *.d


### PR DESCRIPTION
Seems like we should be ignoring these font files? Let me know.