### PR TITLE
Adding CircleCI build file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,36 +13,32 @@ jobs:
             yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
             yum -y update
       - run:
-          name: Install dependencies
+          name: Install libdispatch
           command: |
-            yum -y install git
-            yum -y install libffi libffi-devel
-            yum -y install libxml2 libxml2-devel
-            yum -y install gnutls gnutls-devel
-            yum -y install libxslt libxslt-devel
-            yum -y install libicu libicu-devel
-            yum -y install libjpeg libjpeg-devel
-            yum -y install libtiff libtiff-devel
-            yum -y install libpng libpng-devel
-            yum -y install freetype freetype-devel
-            yum -y install libart_lgpl libart_lgpl-devel
-            yum -y install libX11 libX11-devel
-            yum -y install libXt libXt-devel
-            yum -y install which
-            yum -y groupinstall "X Window System"
-            yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/clang-libs-7.0.1-4.el7.x86_64.rpm
-            yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/clang-7.0.1-4.el7.x86_64.rpm
             yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/libdispatch-1.3.1121-3.el7.x86_64.rpm
             yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/libdispatch-devel-1.3.1121-3.el7.x86_64.rpm
+      - run:
+          name: Install libobjc2
+          command: |
             yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/libobjc2-2.0-3.el7.x86_64.rpm
             yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/libobjc2-devel-2.0-3.el7.x86_64.rpm
-            yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/llvm-libs-7.0.1-3.el7.x86_64.rpm
-            yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-gnustep-1.26.0_0.25.0-2.el7.x86_64.rpm
-            yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-gnustep-devel-1.26.0_0.25.0-2.el7.x86_64.rpm
+      - run:
+          name: Install NextSpace Core files
+          command: |
             yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-core-0.95-8.el7.x86_64.rpm
             yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-core-devel-0.95-8.el7.x86_64.rpm
       - run:
-          name: Build and install libs-base
+          name: Install LLVM, Clang and Git
+          command: |
+            yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/llvm-libs-7.0.1-3.el7.x86_64.rpm
+            yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/clang-libs-7.0.1-4.el7.x86_64.rpm
+            yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/clang-7.0.1-4.el7.x86_64.rpm
+            yum -y install git which
+      - run:
+          name: GNUstep Base - install build dependencies
+          command: yum -y install libffi-devel gnutls-devel openssl-devel libicu-devel libxml2-devel libxslt-devel
+      - run:
+          name: GNUstep Base - build and install
           command: |
             git clone https://github.com/gnustep/libs-base
             cd libs-base
@@ -51,7 +47,10 @@ jobs:
             make install
             ldconfig
       - run:
-          name: Build and install libs-gui
+          name: GNUstep GUI - install build dependencies
+          command: yum -y install giflib-devel libjpeg-turbo-devel libpng-devel libtiff-devel libao-devel libsndfile-devel
+      - run:
+          name: GNUstep GUI - build and install
           command: |
             git clone https://github.com/gnustep/libs-gui
             cd libs-gui
@@ -61,7 +60,11 @@ jobs:
             make install
             ldconfig
       - run:
-          name: Build and install libs-back
+          name: GNUstep Back - install build dependencies
+          command: yum -y install libart_lgpl-devel freetype-devel mesa-libGL-devel libX11-devel libXcursor-devel \
+                   libXext-devel libXfixes-devel libXmu-devel libXt-devel libXrandr-devel
+      - run:
+          name:  GNUstep Back - build and install
           command: |
             git clone https://github.com/gnustep/libs-back
             cd libs-back
@@ -75,20 +78,21 @@ jobs:
       - run:
           name: Build and install Frameworks
           command: |
-            cd /root/nextspace/Frameworks
+            cd /root/nextspace
+            cd Frameworks
             yum -y install `grep "BuildRequires" nextspace-frameworks.spec | awk -c '{print $2}'`
-            make
+            make 
             make install
             ldconfig
       - run:
           name: Build and install Applications
           command: |
-            cd /root/nextspace/Libraries/libwraster
-            make 
-            make install
-            cd /root/nextspace/Applications
-            make 
+            cd /root/nextspace
             cd Applications
             yum -y install `grep "BuildRequires" nextspace-applications.spec | awk -c '{print $2}'`
-            make
+            cd ../Libraries/libwraster
+            make 
+            make install
+            cd ../../Applications
+            make 
             make install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,166 @@
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: amd64/centos:7
+    steps:
+      - run:
+          name: Add EPEL
+          command: yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+      - run:
+          name: Update Yum
+          command: yum -y update
+      - run:
+          name: Install git
+          command: yum -y install git
+      - run:
+          name: Install libffi
+          command: yum -y install libffi libffi-devel
+      - run:
+          name: Install libxml2
+          command: yum -y install libxml2 libxml2-devel
+      - run:
+          name: Install gnutls
+          command: yum -y install gnutls gnutls-devel
+      - run:
+          name: Install libxslt
+          command: yum -y install libxslt libxslt-devel
+      - run:
+          name: Install libicu
+          command: yum -y install libicu libicu-devel
+      - run:
+          name: Install libjpeg
+          command: yum -y install libjpeg libjpeg-devel
+      - run:
+          name: Install libtiff
+          command: yum -y install libtiff libtiff-devel
+      - run:
+          name: Install libpng
+          command: yum -y install libpng libpng-devel
+      - run:
+          name: Install freetype
+          command: yum -y install freetype freetype-devel
+      - run:
+          name: Install libart
+          command: yum -y install libart_lgpl libart_lgpl-devel
+      - run:
+          name: Install libX11
+          command: yum -y install libX11 libX11-devel
+      - run:
+          name: Install libXt
+          command: yum -y install libXt libXt-devel
+      - run:
+          name: Install which
+          command: yum -y install which
+      - run:
+          name: Install X Window System
+          command: yum -y groupinstall "X Window System"
+      - run:
+          name: Install clang-libs
+          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/clang-libs-7.0.1-4.el7.x86_64.rpm
+      - run:
+          name: Install clang
+          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/clang-7.0.1-4.el7.x86_64.rpm
+      - run:
+          name: Install libdispatch
+          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/libdispatch-1.3.1121-3.el7.x86_64.rpm
+      - run:
+          name: Install libdispatch-devel
+          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/libdispatch-devel-1.3.1121-3.el7.x86_64.rpm
+      - run:
+          name: Install libobjc2
+          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/libobjc2-2.0-3.el7.x86_64.rpm
+      - run:
+          name: Install libojc2-devel
+          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/libobjc2-devel-2.0-3.el7.x86_64.rpm
+      - run:
+          name: Install llvm-libs
+          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/llvm-libs-7.0.1-3.el7.x86_64.rpm
+      - run:
+          name: Install nextspace-gnustep
+          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-gnustep-1.26.0_0.25.0-2.el7.x86_64.rpm
+      - run:
+          name: Install nextspace-gnustep-devel
+          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-gnustep-devel-1.26.0_0.25.0-2.el7.x86_64.rpm
+      - run:
+          name: Install nextspace-core
+          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-core-0.95-8.el7.x86_64.rpm
+      - run:
+          name: Install nextspace-core-devel
+          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-core-devel-0.95-8.el7.x86_64.rpm
+      - run:
+          name: Install nextspace-frameworks
+          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-frameworks-0.85-2.el7.x86_64.rpm
+      - run:
+          name: Install nextspace-frameworks-devel
+          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-frameworks-devel-0.85-2.el7.x86_64.rpm
+      - run:
+          name: Install nextspace-applications
+          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-applications-0.85-3.el7.x86_64.rpm
+      - run:
+          name: Install nextspace-applications-devel
+          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-applications-devel-0.85-3.el7.x86_64.rpm
+      - run:
+          name: Source profile
+          command: source /etc/profile.d/nextspace.sh
+      - run:
+          name: Build and install libs-base
+          command: |
+            source /etc/profile.d/nextspace.sh
+            CC=/usr/bin/clang
+            GNUSTEP_MAKEFILES=/Developer/Makefiles
+            git clone https://github.com/gnustep/libs-base
+            cd libs-base
+            ./configure --disable-mixedabi
+            make
+            make install
+            ldconfig
+      - run:
+          name: Build and install libs-gui
+          command: |
+            source /etc/profile.d/nextspace.sh
+            CC=/usr/bin/clang
+            GNUSTEP_MAKEFILES=/Developer/Makefiles
+            git clone https://github.com/gnustep/libs-gui
+            cd libs-gui
+            git checkout nextspace
+            ./configure
+            make
+            make install
+            ldconfig
+      - run:
+          name: Build and install libs-back
+          command: |
+            source /etc/profile.d/nextspace.sh
+            CC=/usr/bin/clang
+            GNUSTEP_MAKEFILES=/Developer/Makefiles
+            git clone https://github.com/gnustep/libs-back
+            cd libs-back
+            git checkout nextspace
+            ./configure --enable-graphics=art --with-name=art
+            make
+            make fonts=no install
+            ldconfig
+      - checkout:
+          path: /root/nextspace
+      - run:
+          name: Build and install Frameworks
+          command: |
+            cd /root/nextspace
+            source /etc/profile.d/nextspace.sh
+            CC=/usr/bin/clang
+            cd Frameworks
+            yum -y install `grep "BuildRequires" nextspace-frameworks.spec | awk -c '{print $2}'`
+            make
+            make install
+            ldconfig
+      - run:
+          name: Build and install Applications
+          command: |
+            cd /root/nextspace
+            source /etc/profile.d/nextspace.sh
+            CC=/usr/bin/clang
+            cd Applications
+            yum -y install `grep "BuildRequires" nextspace-applications.spec | awk -c '{print $2}'`
+            make
+            make install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,112 +3,47 @@ jobs:
   build:
     docker:
       - image: amd64/centos:7
+      environment:
+        CC: /usr/bin/clang
+        BASH_ENV: /etc/profile.d/nextspace.sh
     steps:
       - run:
-          name: Add EPEL
-          command: yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+          name: Setup Yum
+          command: |
+            yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+            yum -y update
       - run:
-          name: Update Yum
-          command: yum -y update
-      - run:
-          name: Install git
-          command: yum -y install git
-      - run:
-          name: Install libffi
-          command: yum -y install libffi libffi-devel
-      - run:
-          name: Install libxml2
-          command: yum -y install libxml2 libxml2-devel
-      - run:
-          name: Install gnutls
-          command: yum -y install gnutls gnutls-devel
-      - run:
-          name: Install libxslt
-          command: yum -y install libxslt libxslt-devel
-      - run:
-          name: Install libicu
-          command: yum -y install libicu libicu-devel
-      - run:
-          name: Install libjpeg
-          command: yum -y install libjpeg libjpeg-devel
-      - run:
-          name: Install libtiff
-          command: yum -y install libtiff libtiff-devel
-      - run:
-          name: Install libpng
-          command: yum -y install libpng libpng-devel
-      - run:
-          name: Install freetype
-          command: yum -y install freetype freetype-devel
-      - run:
-          name: Install libart
-          command: yum -y install libart_lgpl libart_lgpl-devel
-      - run:
-          name: Install libX11
-          command: yum -y install libX11 libX11-devel
-      - run:
-          name: Install libXt
-          command: yum -y install libXt libXt-devel
-      - run:
-          name: Install which
-          command: yum -y install which
-      - run:
-          name: Install X Window System
-          command: yum -y groupinstall "X Window System"
-      - run:
-          name: Install clang-libs
-          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/clang-libs-7.0.1-4.el7.x86_64.rpm
-      - run:
-          name: Install clang
-          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/clang-7.0.1-4.el7.x86_64.rpm
-      - run:
-          name: Install libdispatch
-          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/libdispatch-1.3.1121-3.el7.x86_64.rpm
-      - run:
-          name: Install libdispatch-devel
-          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/libdispatch-devel-1.3.1121-3.el7.x86_64.rpm
-      - run:
-          name: Install libobjc2
-          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/libobjc2-2.0-3.el7.x86_64.rpm
-      - run:
-          name: Install libojc2-devel
-          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/libobjc2-devel-2.0-3.el7.x86_64.rpm
-      - run:
-          name: Install llvm-libs
-          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/llvm-libs-7.0.1-3.el7.x86_64.rpm
-      - run:
-          name: Install nextspace-gnustep
-          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-gnustep-1.26.0_0.25.0-2.el7.x86_64.rpm
-      - run:
-          name: Install nextspace-gnustep-devel
-          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-gnustep-devel-1.26.0_0.25.0-2.el7.x86_64.rpm
-      - run:
-          name: Install nextspace-core
-          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-core-0.95-8.el7.x86_64.rpm
-      - run:
-          name: Install nextspace-core-devel
-          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-core-devel-0.95-8.el7.x86_64.rpm
-      - run:
-          name: Install nextspace-frameworks
-          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-frameworks-0.85-2.el7.x86_64.rpm
-      - run:
-          name: Install nextspace-frameworks-devel
-          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-frameworks-devel-0.85-2.el7.x86_64.rpm
-      - run:
-          name: Install nextspace-applications
-          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-applications-0.85-3.el7.x86_64.rpm
-      - run:
-          name: Install nextspace-applications-devel
-          command: yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-applications-devel-0.85-3.el7.x86_64.rpm
-      - run:
-          name: Source profile
-          command: source /etc/profile.d/nextspace.sh
+          name: Install dependencies
+          command: |
+            yum -y install git
+            yum -y install libffi libffi-devel
+            yum -y install libxml2 libxml2-devel
+            yum -y install gnutls gnutls-devel
+            yum -y install libxslt libxslt-devel
+            yum -y install libicu libicu-devel
+            yum -y install libjpeg libjpeg-devel
+            yum -y install libtiff libtiff-devel
+            yum -y install libpng libpng-devel
+            yum -y install freetype freetype-devel
+            yum -y install libart_lgpl libart_lgpl-devel
+            yum -y install libX11 libX11-devel
+            yum -y install libXt libXt-devel
+            yum -y install which
+            yum -y groupinstall "X Window System"
+            yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/clang-libs-7.0.1-4.el7.x86_64.rpm
+            yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/clang-7.0.1-4.el7.x86_64.rpm
+            yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/libdispatch-1.3.1121-3.el7.x86_64.rpm
+            yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/libdispatch-devel-1.3.1121-3.el7.x86_64.rpm
+            yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/libobjc2-2.0-3.el7.x86_64.rpm
+            yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/libobjc2-devel-2.0-3.el7.x86_64.rpm
+            yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/llvm-libs-7.0.1-3.el7.x86_64.rpm
+            yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-gnustep-1.26.0_0.25.0-2.el7.x86_64.rpm
+            yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-gnustep-devel-1.26.0_0.25.0-2.el7.x86_64.rpm
+            yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-core-0.95-8.el7.x86_64.rpm
+            yum -y install https://github.com/trunkmaster/nextspace/releases/download/0.85/nextspace-core-devel-0.95-8.el7.x86_64.rpm
       - run:
           name: Build and install libs-base
           command: |
-            source /etc/profile.d/nextspace.sh
-            CC=/usr/bin/clang
-            GNUSTEP_MAKEFILES=/Developer/Makefiles
             git clone https://github.com/gnustep/libs-base
             cd libs-base
             ./configure --disable-mixedabi
@@ -118,9 +53,6 @@ jobs:
       - run:
           name: Build and install libs-gui
           command: |
-            source /etc/profile.d/nextspace.sh
-            CC=/usr/bin/clang
-            GNUSTEP_MAKEFILES=/Developer/Makefiles
             git clone https://github.com/gnustep/libs-gui
             cd libs-gui
             git checkout nextspace
@@ -131,9 +63,6 @@ jobs:
       - run:
           name: Build and install libs-back
           command: |
-            source /etc/profile.d/nextspace.sh
-            CC=/usr/bin/clang
-            GNUSTEP_MAKEFILES=/Developer/Makefiles
             git clone https://github.com/gnustep/libs-back
             cd libs-back
             git checkout nextspace
@@ -147,8 +76,6 @@ jobs:
           name: Build and install Frameworks
           command: |
             cd /root/nextspace
-            source /etc/profile.d/nextspace.sh
-            CC=/usr/bin/clang
             cd Frameworks
             yum -y install `grep "BuildRequires" nextspace-frameworks.spec | awk -c '{print $2}'`
             make
@@ -158,8 +85,6 @@ jobs:
           name: Build and install Applications
           command: |
             cd /root/nextspace
-            source /etc/profile.d/nextspace.sh
-            CC=/usr/bin/clang
             cd Applications
             yum -y install `grep "BuildRequires" nextspace-applications.spec | awk -c '{print $2}'`
             make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,8 +75,7 @@ jobs:
       - run:
           name: Build and install Frameworks
           command: |
-            cd /root/nextspace
-            cd Frameworks
+            cd /root/nextspace/Frameworks
             yum -y install `grep "BuildRequires" nextspace-frameworks.spec | awk -c '{print $2}'`
             make
             make install
@@ -84,7 +83,11 @@ jobs:
       - run:
           name: Build and install Applications
           command: |
-            cd /root/nextspace
+            cd /root/nextspace/Libraries/libwraster
+            make 
+            make install
+            cd /root/nextspace/Applications
+            make 
             cd Applications
             yum -y install `grep "BuildRequires" nextspace-applications.spec | awk -c '{print $2}'`
             make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,9 @@ jobs:
   build:
     docker:
       - image: amd64/centos:7
-      environment:
-        CC: /usr/bin/clang
-        BASH_ENV: /etc/profile.d/nextspace.sh
+    environment:
+      CC: /usr/bin/clang
+      BASH_ENV: /etc/profile.d/nextspace.sh
     steps:
       - run:
           name: Setup Yum


### PR DESCRIPTION
This enables CI support through CircleCI. You can see the successful build here: https://app.circleci.com/pipelines/github/enzuru/nextspace/35/workflows/6026dbbb-b797-44a9-8ed3-ce7dfb089704/jobs/35

There is room for improvement. I may be installing some packages I don't need, I could organize the steps differently, and I'm not caching nearly enough. I think it's better to get rudimentary CI support in earlier in development and improve it later, but I'll accept your direction.

This script would also be fairly easy to adapt to other CI platforms.