### PR TITLE
Increase build robustness in Workspace.app

### DIFF
--- a/Applications/Workspace/GNUmakefile
+++ b/Applications/Workspace/GNUmakefile
@@ -8,7 +8,7 @@ include $(GNUSTEP_MAKEFILES)/common.make
 
 PACKAGE_NAME = Workspace
 VERSION = 0.8
-REVISION = "`git log -n 1 --date=short --format=format:"%h, %ad"`"
+REVISION := "$(shell git log -n 1 --date=short --format=format:"%h, %ad" 2>/dev/null || echo unknown)"
 APP_NAME = Workspace
 OS_NAME=`./os-release`
 $(APP_NAME)_APPLICATION_ICON = app-$(OS_NAME)-48.tiff

--- a/Applications/Workspace/GNUmakefile.postamble
+++ b/Applications/Workspace/GNUmakefile.postamble
@@ -46,7 +46,7 @@ after-all::
 after-clean::
 	@ echo "Making clean in WM ... "
 	@ echo " Cleaning in $(WM_DIR)/WINGs ..."
-	@ cd $(WM_DIR)/WINGs; make clean > /dev/null 2>&1
+	-@ cd $(WM_DIR)/WINGs; make clean > /dev/null 2>&1
 
 before-install::
 	@ mkdir -p $(APP_WRAPPER_INSTALLED)

--- a/Applications/Workspace/os-release
+++ b/Applications/Workspace/os-release
@@ -1,3 +1,3 @@
 #!/bin/sh
 #echo `grep ^NAME= /etc/os-release | awk -F\" -c '{print $2}' | awk -c '{print $1}'`
-echo `grep ^ID= /etc/os-release | awk -F\= -c '{print $2}' | tr -d \"`
+echo `grep ^ID= /etc/os-release | awk -F\= '{print $2}' | tr -d \"`


### PR DESCRIPTION
These changes are currently patches in the Debian builds but I think they're more generally useful:

- Evaluate git revision only once, and provide a default if no git information is available
- Don't expect awk to be gnu awk (we don't seem to need the --compatible flag)
- `make clean` shouldn't fail before the first build