### PR TITLE
Apps/TimeMon: Install to LOCAL like other user visible apps

### DIFF
--- a/Applications/TimeMon/GNUmakefile
+++ b/Applications/TimeMon/GNUmakefile
@@ -1,5 +1,6 @@
 # -*- mode: makefile-gmake -*-
 
+GNUSTEP_INSTALLATION_DOMAIN = LOCAL
 include $(GNUSTEP_MAKEFILES)/common.make
 
 # The application to be compiled


### PR DESCRIPTION
This way it ends up in /Applications like it's supposed to.

Fixes #270 