### PR TITLE
Add gitmodules to prevent crashing with obs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Frameworks/DBusKit"]
+	path = Frameworks/DBusKit
+	url = https://github.com/gnustep/libs-dbuskit


### PR DESCRIPTION
I got an error when trying to add the sources in the buildservice. It seems like .gitmodules is missing.