### PR TITLE
Debian: Don't try to unapply patches

### DIFF
--- a/Packaging/Debian/create-dscs.sh
+++ b/Packaging/Debian/create-dscs.sh
@@ -12,7 +12,7 @@ create_dsc() {
 	cd "$dir"
 	if [ -f debian/patches/series ]; then
 		cat debian/patches/series | while read filename; do
-			patch -p1 -i "debian/patches/$filename"
+			patch -N -p1 -i "debian/patches/$filename"
 	       	done
 	fi
 	dpkg-source -b .


### PR DESCRIPTION
This is necessary because the nextspace-application package adds a bunch of files (WMState et al) and patch(1) makes that an interactive decision if those files already exist.