### PR TITLE
fix dwz failing on debian buster builds

### DIFF
--- a/Packaging/Debian/README.md
+++ b/Packaging/Debian/README.md
@@ -36,7 +36,7 @@ from within the chroot to store it in `/var/cache/pbuilder/result`. That
 initial system comes from a cached filesystem tarball that you have to
 create first, using
 
-    $ sudo pbuild create --distribution sid
+    $ sudo pbuilder create --distribution sid
 
 If you want to build for a different distribution, adapt as appropriate
 (but sid is the best tested distribution).

--- a/Packaging/Debian/build-from-dsc.sh
+++ b/Packaging/Debian/build-from-dsc.sh
@@ -18,11 +18,11 @@ build() {
 
 method=${1-pbuilder}
 
-build "nextspace" "$(map_version_from_commit ${nextspace_version})"
 
 build "libdispatch" "${libdispatch_version}"
 build "libobjc2" "${libobjc2_version}"
 build "nextspace-make" "${gnustep_make_version}"
+build "nextspace" "$(map_version_from_commit ${nextspace_version})"
 build "nextspace-base" "${gnustep_base_version}"
 build "nextspace-gui" "${gnustep_gui_version}"
 build "nextspace-back" "${gnustep_back_version}"

--- a/Packaging/Debian/libdispatch-5.1.5/debian/rules
+++ b/Packaging/Debian/libdispatch-5.1.5/debian/rules
@@ -19,3 +19,6 @@ override_dh_auto_install:
 
 %:
 	dh $@
+
+override_dh_dwz:
+	dh_dwz || true

--- a/Packaging/Debian/libobjc2-2.0/debian/rules
+++ b/Packaging/Debian/libobjc2-2.0/debian/rules
@@ -33,3 +33,6 @@ override_dh_auto_configure:
 	-DCMAKE_BUILD_TYPE=Release \
 	-DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)
 
+
+override_dh_dwz:
+	dh_dwz || true

--- a/Packaging/Debian/nextspace-0.90+20200626.git2b996873/debian/rules
+++ b/Packaging/Debian/nextspace-0.90+20200626.git2b996873/debian/rules
@@ -10,3 +10,6 @@ export DESTDIR=$(CURDIR)/debian/tmp
 
 override_dh_auto_build override_dh_auto_clean override_dh_auto_test override_dh_auto_install:
 	true
+
+override_dh_dwz:
+	dh_dwz || true

--- a/Packaging/Debian/nextspace-applications-0.90+20200626.git2b996873/debian/rules
+++ b/Packaging/Debian/nextspace-applications-0.90+20200626.git2b996873/debian/rules
@@ -9,3 +9,6 @@ export DEB_LDFLAGS_MAINT_APPEND = -Wl,--no-undefined -Wl,--as-needed
 
 %:
 	dh $@
+
+override_dh_dwz:
+	dh_dwz || true

--- a/Packaging/Debian/nextspace-back-0.28.0+nextspace/debian/rules
+++ b/Packaging/Debian/nextspace-back-0.28.0+nextspace/debian/rules
@@ -73,3 +73,6 @@ override_dh_shlibdeps:
 	  > debian/shlibs.local
 	dh_shlibdeps
 	rm debian/shlibs.local
+
+override_dh_dwz:
+	dh_dwz || true

--- a/Packaging/Debian/nextspace-base-1.27.0/debian/rules
+++ b/Packaging/Debian/nextspace-base-1.27.0/debian/rules
@@ -102,3 +102,6 @@ override_dh_shlibdeps:
 # gnustep-base-runtime is added as additional dependency.
 	dh_makeshlibs -p$(p_lib) \
 	  -V '$(p_lib) (>= $(v_base)), $(p_run) (>= $(v_base))'
+
+override_dh_dwz:
+	dh_dwz || true

--- a/Packaging/Debian/nextspace-frameworks-0.90+20200626.git2b996873/debian/rules
+++ b/Packaging/Debian/nextspace-frameworks-0.90+20200626.git2b996873/debian/rules
@@ -13,3 +13,6 @@ export messages=yes
 
 override_dh_link:
 	dh_link
+
+override_dh_dwz:
+	dh_dwz || true

--- a/Packaging/Debian/nextspace-gorm.app-1.2.26/debian/rules
+++ b/Packaging/Debian/nextspace-gorm.app-1.2.26/debian/rules
@@ -27,3 +27,6 @@ override_dh_clean:
 override_dh_auto_install:
 	$(MAKE) install DESTDIR=$(CURDIR)/debian/tmp
 	$(MAKE) -C Documentation install DESTDIR=$(CURDIR)/debian/tmp
+
+override_dh_dwz:
+	dh_dwz || true

--- a/Packaging/Debian/nextspace-gui-0.28.0+nextspace/debian/rules
+++ b/Packaging/Debian/nextspace-gui-0.28.0+nextspace/debian/rules
@@ -118,3 +118,6 @@ override_dh_shlibdeps:
 # Then recalculate dependencies of shared lib
 	dh_makeshlibs -p$(p_lib) \
 	    -V '$(p_lib) (>= $(v_gui)), nextspace-gui-runtime (>= $(v_gui)), nextspace-back$(sov_gui) (>= $(v_gui))'
+
+override_dh_dwz:
+	dh_dwz || true

--- a/Packaging/Debian/nextspace-make-2.7.0/debian/rules
+++ b/Packaging/Debian/nextspace-make-2.7.0/debian/rules
@@ -45,3 +45,6 @@ override_dh_auto_install:
 	dh_auto_install
 	rm $(CURDIR)/debian/tmp/usr/NextSpace/bin/opentool
 	-rm $(CURDIR)/debian/tmp/usr/NextSpace/Documentation/man/man1/opentool.1.gz
+
+override_dh_dwz:
+	dh_dwz || true

--- a/Packaging/Debian/nextspace-projectcenter.app-0.6.2/debian/rules
+++ b/Packaging/Debian/nextspace-projectcenter.app-0.6.2/debian/rules
@@ -20,3 +20,6 @@ export DEB_BUILD_MAINT_OPTIONS=hardening=+all
 override_dh_makeshlibs:
 # Avoid lintian warnings for the library; it is installed as private.
 	dh_makeshlibs --noscripts
+
+override_dh_dwz:
+	dh_dwz || true


### PR DESCRIPTION
- fix dwz failing on debian buster builds
- put build-from-dsc.sh stuff on the right order
- fix a typo on Packaging/Debian/README.md