### PR TITLE
NSWorkspace openFile doesn't support .app and directories properly

### DIFF
--- a/Applications/Workspace/Controller+NSWorkspace.m
+++ b/Applications/Workspace/Controller+NSWorkspace.m
@@ -83,6 +83,18 @@ static NSImage	*unknownTool = nil;
 // Preferences
 - (void)_workspacePreferencesChanged:(NSNotification *)aNotification;
 
+// open files
+- (BOOL)_connectToApplication:(NSString*)appName
+                       openFile:(NSString*)fullPath
+                  andDeactivate:(BOOL)flag;
+
+- (BOOL)_doOpenFile:(NSString*)fullPath
+          fromImage:(NSImage*)anImage
+                 at:(NSPoint)point
+             inView:(NSView*)aView
+            withApp:(NSString*)prefAppName
+         deactivate:(BOOL)deactivate;
+
 // application communication
 - (BOOL)_launchApplication:(NSString*)appName
                  arguments:(NSArray*)args;
@@ -289,143 +301,12 @@ static NSString		*_rootPath = @"/";
 }
 
 // NEXTSPACE
-- (BOOL)openFile: (NSString*)fullPath
+- (BOOL)openFile:(NSString*)fullPath
        fromImage:(NSImage*)anImage
               at:(NSPoint)point
           inView:(NSView*)aView
 {
-  NSString      *fileType = nil, *appName = nil;
-  NSPoint       destPoint = {0,0};
-  NSFileManager *fm = [NSFileManager defaultManager];
-  NSDictionary  *fattrs = nil;
-
-  if (![fm fileExistsAtPath:fullPath]) {
-    NXTRunAlertPanel(_(@"Workspace"),
-                     _(@"File '%@' does not exist!"), 
-                     nil, nil, nil, [fullPath lastPathComponent]);
-    return NO;
-  }
-
-  // Sliding coordinates
-  point = [[aView window] convertBaseToScreen:[aView convertPoint:point
-                                                           toView:nil]];
-
-  // Get file type and application name
-  [self getInfoForFile:fullPath application:&appName type:&fileType];
-
-  // Application is not associated - set `appName` to default editor.
-  if (appName == nil) {
-    if ([self _extension:[fullPath pathExtension] role:nil app:&appName] == NO) {
-      appName = [[NXTDefaults userDefaults] objectForKey:@"DefaultEditor"];
-      if (!appName || [appName isEqualToString:@""]) {
-        appName = @"TextEdit";
-      }
-    }
-  }
-
-  NSDebugLLog(@"Workspace", @"[Workspace] openFile: type '%@' with app: %@",
-              fileType, appName);
-  
-  if ([fileType isEqualToString:NSApplicationFileType]) {
-    // .app should be launched
-      NSString     *wmName;
-      NSBundle     *appBundle;
-      NSDictionary *appInfo;
-      NSString     *iconPath;
-      NSString     *launchPath;
-      
-      // Don't launch ourself and Login panel
-      if ([appName isEqualToString:@"Workspace"] ||
-          [appName isEqualToString:@"Login"]) {
-        return YES;
-      }
-
-      appBundle = [[NSBundle alloc] initWithPath:fullPath];
-      appInfo = [appBundle infoDictionary];
-      if (!appInfo) {
-        NXTRunAlertPanel(_(@"Workspace"),
-                         _(@"Failed to start application \"%@\".\n"
-                           "Application info dictionary was not found or broken."), 
-                         nil, nil, nil, appName);
-        return NO;
-      }
-      wmName = [appInfo objectForKey:@"NSExecutable"];
-      if (!wmName) {
-        NSLog(@"No application NSExecutable found.");
-        NXTRunAlertPanel(_(@"Workspace"),
-                         _(@"Failed to start application \"%@\".\n"
-                           "Executable name is unknown (info doctionary is broken)."),
-                         nil, nil, nil, appName);
-        return NO;
-      }
-      if ([[wmName componentsSeparatedByString:@"."] count] == 1) {
-        wmName = [NSString stringWithFormat:@"%@.GNUstep",
-                           [wmName stringByDeletingPathExtension]];
-      }
-      launchPath = [self locateApplicationBinary:fullPath];
-      if (launchPath == nil) {
-        NXTRunAlertPanel(_(@"Workspace"),
-                         _(@"Failed to start application \"%@\".\n"
-                           "Executable \"%@\" was not found.\n"),
-                         nil, nil, nil, appName, fullPath);
-        return NO;
-      }
-      iconPath = [appBundle pathForResource:[appInfo objectForKey:@"NSIcon"]
-                                     ofType:nil];
-      
-      WMCreateLaunchingIcon(wmName, launchPath, anImage, point, iconPath);
-      
-      if ([self launchApplication:fullPath] == NO) {
-        NXTRunAlertPanel(_(@"Workspace"),
-                         _(@"Failed to start application \"%@\""), 
-                         nil, nil, nil, appName);
-        return NO;
-      }
-      return YES;
-  }
-  else if ([fileType isEqualToString:NSDirectoryFileType] ||
-           [fileType isEqualToString:NSFilesystemFileType] ||
-           [wrappers containsObject:[fullPath pathExtension]]) {
-      // Open new FileViewer window
-      [self openNewViewerIfNotExistRootedAt:fullPath];
-      return YES;
-    }
-  else if (appName) {
-    // .app found for opening file type
-    NSBundle     *appBundle;
-    NSDictionary *appInfo;
-    NSString     *wmName;
-    NSString     *iconPath;
-    NSString     *launchPath;
-      
-    appBundle = [self bundleForApp:appName];
-    if (appBundle) {
-      appInfo = [appBundle infoDictionary];
-      iconPath = [appBundle pathForResource:[appInfo objectForKey:@"NSIcon"]
-                                     ofType:nil];
-      
-      wmName = [appInfo objectForKey:@"NSExecutable"];
-      if ([[wmName componentsSeparatedByString:@"."] count] == 1) {
-        wmName = [NSString stringWithFormat:@"%@.GNUstep",
-                           [appName stringByDeletingPathExtension]];
-      }
-      launchPath = [self locateApplicationBinary:appName];
-      if (launchPath == nil) {
-        return NO;
-      }
-      WMCreateLaunchingIcon(wmName, launchPath, anImage, point, iconPath);
-    }
-      
-    if (![self openFile:fullPath withApplication:appName andDeactivate:YES]) {
-      NXTRunAlertPanel(_(@"Workspace"),
-                       _(@"Failed to start application \"%@\" for file \"%@\""), 
-                       nil, nil, nil, appName, [fullPath lastPathComponent]);
-      return NO;
-    }
-    return YES;
-  }
-
-  return NO;
+  return [self _doOpenFile:fullPath fromImage:anImage at:point inView:aView withApp:nil deactivate:YES];
 }
 
 - (BOOL) openFile:(NSString*)fullPath
@@ -439,45 +320,7 @@ static NSString		*_rootPath = @"/";
  withApplication:(NSString*)appName
    andDeactivate:(BOOL)flag
 {
-  id app;
-
-  if (appName == nil) {
-    if ([self _extension:[fullPath pathExtension] role:nil app:&appName] == NO) {
-      appName = [[NXTDefaults userDefaults] objectForKey:@"DefaultEditor"];
-      if (!appName || [appName isEqualToString:@""]) {
-        appName = @"TextEdit";
-      }
-    }
-  }
-
-  app = [self _connectApplication:appName];
-  if (app == nil) {
-    NSArray *args;
-
-    args = [NSArray arrayWithObjects:@"-GSFilePath",fullPath,nil];
-    return [self _launchApplication:appName arguments:args];
-  }
-  else {
-    @try {
-      if (flag == NO) {
-        [app application:NSApp openFileWithoutUI:fullPath];
-      }
-      else {
-        [app application:NSApp openFile:fullPath];
-      }
-    }
-    @catch (NSException *e) {
-      NSWarnLog(@"Failed to contact '%@' to open file", appName);
-      NXTRunAlertPanel(_(@"Workspace"),
-                       _(@"Failed to contact app '%@' to open file"), 
-                       nil, nil, nil, appName);
-      return NO;
-    }
-  }
-  if (flag) {
-    [NSApp deactivate];
-  }
-  return YES;
+  return [self _doOpenFile:fullPath fromImage:nil at:NSZeroPoint inView:nil withApp:appName deactivate:flag];
 }
 
 - (BOOL)openTempFile:(NSString*)fullPath
@@ -1059,6 +902,191 @@ static NSString		*_rootPath = @"/";
 @end
 
 @implementation Controller (NSWorkspacePrivate)
+  
+//-----------------------------------------------------------------------------
+//--- open files
+//-----------------------------------------------------------------------------
+
+// you should never call this directly, use _doOpenFile:fromImage...
+- (BOOL)_connectToApplication:(NSString*)appName
+                       openFile:(NSString*)fullPath
+                  andDeactivate:(BOOL)flag
+{
+  id app = [self _connectApplication:appName];
+  if (app == nil) {
+    NSArray *args;
+
+    args = [NSArray arrayWithObjects:@"-GSFilePath",fullPath,nil];
+    return [self _launchApplication:appName arguments:args];
+  }
+  else {
+    @try {
+      if (flag == NO) {
+        [app application:NSApp openFileWithoutUI:fullPath];
+      }
+      else {
+        [app application:NSApp openFile:fullPath];
+      }
+    }
+    @catch (NSException *e) {
+      NSWarnLog(@"Failed to contact '%@' to open file", appName);
+      NXTRunAlertPanel(_(@"Workspace"),
+                       _(@"Failed to contact app '%@' to open file"), 
+                       nil, nil, nil, appName);
+      return NO;
+    }
+  }
+  if (flag) {
+    [NSApp deactivate];
+  }
+  return YES;
+}
+
+- (BOOL)_doOpenFile:(NSString*)fullPath
+          fromImage:(NSImage*)anImage
+                 at:(NSPoint)point
+             inView:(NSView*)aView
+            withApp:(NSString*)appName
+         deactivate:(BOOL)deactivate
+{
+  NSString      *fileType = nil;
+  NSPoint       destPoint = {0,0};
+  NSFileManager *fm = [NSFileManager defaultManager];
+  NSDictionary  *fattrs = nil;
+
+  if (![fm fileExistsAtPath:fullPath]) {
+    NXTRunAlertPanel(_(@"Workspace"),
+                     _(@"File '%@' does not exist!"), 
+                     nil, nil, nil, [fullPath lastPathComponent]);
+    return NO;
+  }
+
+  // Sliding coordinates
+  if (anImage && aView) {
+    point = [[aView window] convertBaseToScreen:[aView convertPoint:point
+                                                             toView:nil]];
+  }
+
+  // Get file type and application name
+  [self getInfoForFile:fullPath application:&appName type:&fileType];
+
+  // Application is not associated - set `appName` to default editor.
+  if (appName == nil) {
+    if ([self _extension:[fullPath pathExtension] role:nil app:&appName] == NO) {
+      appName = [[NXTDefaults userDefaults] objectForKey:@"DefaultEditor"];
+      if (!appName || [appName isEqualToString:@""]) {
+        appName = @"TextEdit";
+      }
+    }
+  }
+
+  NSDebugLLog(@"Workspace", @"[Workspace] openFile: type '%@' with app: %@",
+              fileType, appName);
+  
+  if ([fileType isEqualToString:NSApplicationFileType]) {
+    // .app should be launched
+      NSString     *wmName;
+      NSBundle     *appBundle;
+      NSDictionary *appInfo;
+      NSString     *iconPath;
+      NSString     *launchPath;
+      
+      // Don't launch ourself and Login panel
+      if ([appName isEqualToString:@"Workspace"] ||
+          [appName isEqualToString:@"Login"]) {
+        return YES;
+      }
+
+      appBundle = [[NSBundle alloc] initWithPath:fullPath];
+      appInfo = [appBundle infoDictionary];
+      if (!appInfo) {
+        NXTRunAlertPanel(_(@"Workspace"),
+                         _(@"Failed to start application \"%@\".\n"
+                           "Application info dictionary was not found or broken."), 
+                         nil, nil, nil, appName);
+        return NO;
+      }
+      wmName = [appInfo objectForKey:@"NSExecutable"];
+      if (!wmName) {
+        NSLog(@"No application NSExecutable found.");
+        NXTRunAlertPanel(_(@"Workspace"),
+                         _(@"Failed to start application \"%@\".\n"
+                           "Executable name is unknown (info doctionary is broken)."),
+                         nil, nil, nil, appName);
+        return NO;
+      }
+      if ([[wmName componentsSeparatedByString:@"."] count] == 1) {
+        wmName = [NSString stringWithFormat:@"%@.GNUstep",
+                           [wmName stringByDeletingPathExtension]];
+      }
+      launchPath = [self locateApplicationBinary:fullPath];
+      if (launchPath == nil) {
+        NXTRunAlertPanel(_(@"Workspace"),
+                         _(@"Failed to start application \"%@\".\n"
+                           "Executable \"%@\" was not found.\n"),
+                         nil, nil, nil, appName, fullPath);
+        return NO;
+      }
+
+      if (anImage && aView) {
+        iconPath = [appBundle pathForResource:[appInfo objectForKey:@"NSIcon"]
+                                     ofType:nil];
+      
+        WMCreateLaunchingIcon(wmName, launchPath, anImage, point, iconPath);
+      }
+      
+      if ([self launchApplication:fullPath] == NO) {
+        NXTRunAlertPanel(_(@"Workspace"),
+                         _(@"Failed to start application \"%@\""), 
+                         nil, nil, nil, appName);
+        return NO;
+      }
+      return YES;
+  }
+  else if ([fileType isEqualToString:NSDirectoryFileType] ||
+           [fileType isEqualToString:NSFilesystemFileType] ||
+           [wrappers containsObject:[fullPath pathExtension]]) {
+      // Open new FileViewer window
+      [self openNewViewerIfNotExistRootedAt:fullPath];
+      return YES;
+    }
+  else if (appName) {
+    // .app found for opening file type
+    NSBundle     *appBundle;
+    NSDictionary *appInfo;
+    NSString     *wmName;
+    NSString     *iconPath;
+    NSString     *launchPath;
+      
+    appBundle = [self bundleForApp:appName];
+    if (appBundle) {
+      appInfo = [appBundle infoDictionary];
+      iconPath = [appBundle pathForResource:[appInfo objectForKey:@"NSIcon"]
+                                     ofType:nil];
+      
+      wmName = [appInfo objectForKey:@"NSExecutable"];
+      if ([[wmName componentsSeparatedByString:@"."] count] == 1) {
+        wmName = [NSString stringWithFormat:@"%@.GNUstep",
+                           [appName stringByDeletingPathExtension]];
+      }
+      launchPath = [self locateApplicationBinary:appName];
+      if (launchPath == nil) {
+        return NO;
+      }
+      WMCreateLaunchingIcon(wmName, launchPath, anImage, point, iconPath);
+    }
+      
+    if (![self _connectToApplication:appName openFile:fullPath andDeactivate:deactivate]) {
+      NXTRunAlertPanel(_(@"Workspace"),
+                       _(@"Failed to start application \"%@\" for file \"%@\""), 
+                       nil, nil, nil, appName, [fullPath lastPathComponent]);
+      return NO;
+    }
+    return YES;
+  }
+
+  return NO;
+}
 
 //-----------------------------------------------------------------------------
 //--- Images and icons

--- a/Applications/Workspace/Controller+NSWorkspace.m
+++ b/Applications/Workspace/Controller+NSWorkspace.m
@@ -442,15 +442,7 @@ static NSString		*_rootPath = @"/";
   id app;
 
   if (appName == nil) {
-    /*
-    if ([self _extension:[fullPath pathExtension] role:nil app:&appName] == NO) {
-      appName = [[NXTDefaults userDefaults] objectForKey:@"DefaultEditor"];
-      if (!appName || [appName isEqualToString:@""]) {
-        appName = @"TextEdit";
-        }
-    }
-    */
-    [self openFile:fullPath fromImage:nil at:NSZeroPoint inView:nil];
+    return [self openFile:fullPath fromImage:nil at:NSZeroPoint inView:nil];
   }
 
   app = [self _connectApplication:appName];

--- a/Applications/Workspace/Controller.m
+++ b/Applications/Workspace/Controller.m
@@ -730,23 +730,14 @@ static NSString *WMComputerShouldGoDownNotification = @"WMComputerShouldGoDownNo
                         error:(NSString **)error
 {
   NSString *path = [[pboard stringForType:NSStringPboardType] stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"\n\r"]];
-  BOOL isDir = FALSE;
   path = [path stringByStandardizingPath];
 
-  NSFileManager *fm = [NSFileManager defaultManager];
-  if ([fm fileExistsAtPath:path isDirectory:&isDir]) {
-    if (isDir && [[NSWorkspace sharedWorkspace] isFilePackageAtPath:path] == NO) {
-      [self openNewViewerIfNotExistRootedAt:path];
-    }
-    else {
-      path = [path stringByDeletingLastPathComponent];
-      [self openNewViewerIfNotExistRootedAt:path];
-    }
+  if ([self openFile:path]) {
+    *error = NULL;
   }
   else {
     *error = [NSString stringWithFormat:@"path \"%@\" does not exist", path];
   }
-  
 }
 
 //============================================================================

--- a/System/Library/Preferences/GlobalDefaults.plist
+++ b/System/Library/Preferences/GlobalDefaults.plist
@@ -4,6 +4,8 @@
 <dict>
     <key>GSBackend</key>
     <string>art</string>
+    <key>GSWorkspaceApplication</key>
+    <string>Workspace</string>
     <key>GSCommandKeyString</key>
     <string></string>
     <key>GSFirstAlternateKey</key>


### PR DESCRIPTION
NSWorkspace openFile should be able to handle different types of paths.
- if path is an app, launch it
- if path is a bundle, open it in associated app
- it path is regular folder, open it in file view

The current implementation of NSWorkspace openFile does not handle all cases in consistent way.
openFile:fromImage:at:inView seems to be much more complete.
This pull request combines both methods in one.