### PR TITLE
fix default border color definition (use RGBA)

### DIFF
--- a/Applications/TimeMon/Percentages.m
+++ b/Applications/TimeMon/Percentages.m
@@ -42,7 +42,6 @@
 {
   NSColor *borderColor = [NSColor colorFromStringRepresentation: 
                                          [defaults stringForKey:@"BorderColor"]];
-  if (!borderColor) borderColor = [NSColor blackColor];
 
   int i;
   static float radii[3]={ 23.0, 17.0, 11.0};
@@ -266,7 +265,7 @@
            @"UserColor":@"0.200 0.467 0.800 1.000",     // A darker blue-green
            @"SystemColor":@"0.000 0.000 1.000 1.000",   // Blue
            @"IOWaitColor":@"1.000 0.800 0.900 1.000",   // Light purple
-           @"BorderColor":@"0.000",                     // Default border color
+           @"BorderColor":@"0.000 0.000 0.000 1.000",   // Default border color
            // For monochrome systems.
            @"IdleGray":@"1.000",                        // White
            @"NiceGray":@"0.667",                        // Light gray


### PR DESCRIPTION
Suppress warning while parsing the default value.