### PR TITLE
System/etc/profile.d: Always reset $UID

### DIFF
--- a/System/etc/profile.d/nextspace.sh
+++ b/System/etc/profile.d/nextspace.sh
@@ -42,9 +42,7 @@ export NS_SYSTEM="/usr/NextSpace"
 # Log file
 #
 export USER=`whoami`
-if [ ! -n "$UID" ];then
-    export UID=`id -u`
-fi
+export UID=`id -u`
 GS_SECURE="/tmp/GNUstepSecure"$UID
 export LOGFILE="$GS_SECURE/console.log"
 if [ ! -d $GS_SECURE ];then


### PR DESCRIPTION
Always reset $UID, so that it's updated when logging in
through loginwindow.system (which already sets it to 0).