### PR TITLE
Adjust Debian Packaging for Debian stable/Buster

### DIFF
--- a/Packaging/Debian/README.md
+++ b/Packaging/Debian/README.md
@@ -41,6 +41,10 @@ create first, using
 If you want to build for a different distribution, adapt as appropriate
 (but sid is the best tested distribution).
 
+To build using Debian stable (Buster) you will need to use clang-8 from backports. So create the pbuilder system this way:
+
+    $ sudo pbuilder create --distribution buster --othermirror "deb http://deb.debian.org/debian buster-backports main"
+
 ### Setting up local packages in pbuilder
 
 Since the packages depend on another but are generated independently,
@@ -84,9 +88,31 @@ Add another file `/etc/pbuilder/hook.d/I99self-archive` containing
     apt-ftparchive packages . > /var/cache/pbuilder/result/Packages
     apt-ftparchive release . > Release
     apt-ftparchive sources . > Sources 2>/dev/null
+    
+For building for stable/Buster with clang from backports you will need to add a further file. `/etc/pbuilder/hook.d/E01apt-backports`:
+
+```
+#!/bin/sh
+set -e
+cat > "/etc/apt/preferences" << EOF
+Package: clang*
+Pin: release a=buster-backports
+Pin-Priority: 999
+
+Package: llvm*   
+Pin: release a=buster-backports
+Pin-Priority: 999
+EOF
+
+apt-get -t buster-backports install --assume-yes clang-8 llvm-8
+
+ln -s /usr/bin/clang-8 /usr/bin/clang
+ln -s /usr/bin/clang++-8 /usr/bin/clang++
+```
 
 Finally make the files executable with
-`chmod +x /etc/pbuilder/hook.d/{D05self-archive,I99self-archive}`.
+`chmod +x /etc/pbuilder/hook.d/{D05self-archive,I99self-archive,E01apt-backports}`.
+
 
 ### Building a package
 

--- a/Packaging/Debian/README.md
+++ b/Packaging/Debian/README.md
@@ -112,7 +112,7 @@ update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-8 50
 ```
 
 Finally make the files executable with
-`chmod +x /etc/pbuilder/hook.d/{D05self-archive,I99self-archive,E01apt-backports}`.
+`chmod +x /etc/pbuilder/hook.d/{D05self-archive,I99self-archive,E01clang-backports}`.
 
 
 ### Building a package

--- a/Packaging/Debian/README.md
+++ b/Packaging/Debian/README.md
@@ -89,7 +89,7 @@ Add another file `/etc/pbuilder/hook.d/I99self-archive` containing
     apt-ftparchive release . > Release
     apt-ftparchive sources . > Sources 2>/dev/null
     
-For building for stable/Buster with clang from backports you will need to add a further file. `/etc/pbuilder/hook.d/E01apt-backports`:
+For building for stable/Buster with clang from backports you will need to add a further file. `/etc/pbuilder/hook.d/E01clang-backports`:
 
 ```
 #!/bin/sh
@@ -105,9 +105,10 @@ Pin-Priority: 999
 EOF
 
 apt-get -t buster-backports install --assume-yes clang-8 llvm-8
-
-ln -s /usr/bin/clang-8 /usr/bin/clang
-ln -s /usr/bin/clang++-8 /usr/bin/clang++
+update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 50
+update-alternatives --install /usr/bin/cc cc /usr/bin/clang-8 50
+update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-8 50
+update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-8 50
 ```
 
 Finally make the files executable with

--- a/Packaging/Debian/README.md
+++ b/Packaging/Debian/README.md
@@ -146,7 +146,7 @@ To install the entire desktop environment, just install the `nextspace-desktop` 
 
 ## Setting things up to install pbuilder created packages locally
 
-To tell `apt` to look for the packages created by pbuilder, just create a file `/etc/apt/sources.list.d/nextspace` containing
+To tell `apt` to look for the packages created by pbuilder, just create a file `/etc/apt/sources.list.d/nextspace.list` containing
 
     deb [trusted=yes] file:///var/cache/pbuilder/result/ ./
 

--- a/Packaging/Debian/libdispatch-5.1.5/debian/control
+++ b/Packaging/Debian/libdispatch-5.1.5/debian/control
@@ -12,7 +12,7 @@ Architecture: any
 Depends: libdispatch0 (= ${binary:Version}), ${misc:Depends}
 Provides: libblocksruntime-dev
 Conflicts: libblocksruntime-dev (<= 0.5)
-Recommends: clang
+Recommends: clang-8
 Description: development files for the Grand Central Dispatch API
  The libdispatch project consists of the user space implementation of 
  the Grand Central Dispatch API as seen in Mac OS X version 10.6 

--- a/Packaging/Debian/libdispatch-5.1.5/debian/control
+++ b/Packaging/Debian/libdispatch-5.1.5/debian/control
@@ -2,7 +2,7 @@ Source: libdispatch
 Priority: extra
 Maintainer: Patrick Georgi <patrick@georgi.software>
 Build-Depends: debhelper-compat (= 12), clang (>= 8) | clang-8, cmake
-Build-Conflicts: clang < 8
+Build-Conflicts: clang (< 8)
 Standards-Version: 4.5.0
 Section: libs
 Homepage: http://libdispatch.macosforge.org/

--- a/Packaging/Debian/libdispatch-5.1.5/debian/control
+++ b/Packaging/Debian/libdispatch-5.1.5/debian/control
@@ -1,7 +1,7 @@
 Source: libdispatch
 Priority: extra
 Maintainer: Patrick Georgi <patrick@georgi.software>
-Build-Depends: debhelper-compat (= 12), clang-8, cmake
+Build-Depends: debhelper-compat (= 12), clang (>= 8), cmake
 Standards-Version: 4.5.0
 Section: libs
 Homepage: http://libdispatch.macosforge.org/
@@ -12,7 +12,7 @@ Architecture: any
 Depends: libdispatch0 (= ${binary:Version}), ${misc:Depends}
 Provides: libblocksruntime-dev
 Conflicts: libblocksruntime-dev (<= 0.5)
-Recommends: clang-8
+Recommends: clang (>= 8)
 Description: development files for the Grand Central Dispatch API
  The libdispatch project consists of the user space implementation of 
  the Grand Central Dispatch API as seen in Mac OS X version 10.6 

--- a/Packaging/Debian/libdispatch-5.1.5/debian/control
+++ b/Packaging/Debian/libdispatch-5.1.5/debian/control
@@ -1,7 +1,7 @@
 Source: libdispatch
 Priority: extra
 Maintainer: Patrick Georgi <patrick@georgi.software>
-Build-Depends: debhelper-compat (= 12), clang (>= 8) || clang-8, cmake
+Build-Depends: debhelper-compat (= 12), clang (>= 8) | clang-8, cmake
 Build-Conflicts: clang < 8
 Standards-Version: 4.5.0
 Section: libs
@@ -13,7 +13,7 @@ Architecture: any
 Depends: libdispatch0 (= ${binary:Version}), ${misc:Depends}
 Provides: libblocksruntime-dev
 Conflicts: libblocksruntime-dev (<= 0.5)
-Recommends: clang (>= 8) || clang-8
+Recommends: clang (>= 8) | clang-8
 Description: development files for the Grand Central Dispatch API
  The libdispatch project consists of the user space implementation of 
  the Grand Central Dispatch API as seen in Mac OS X version 10.6 

--- a/Packaging/Debian/libdispatch-5.1.5/debian/control
+++ b/Packaging/Debian/libdispatch-5.1.5/debian/control
@@ -1,7 +1,8 @@
 Source: libdispatch
 Priority: extra
 Maintainer: Patrick Georgi <patrick@georgi.software>
-Build-Depends: debhelper-compat (= 12), clang (>= 8), cmake
+Build-Depends: debhelper-compat (= 12), clang (>= 8) || clang-8, cmake
+Build-Conflicts: clang < 8
 Standards-Version: 4.5.0
 Section: libs
 Homepage: http://libdispatch.macosforge.org/
@@ -12,7 +13,7 @@ Architecture: any
 Depends: libdispatch0 (= ${binary:Version}), ${misc:Depends}
 Provides: libblocksruntime-dev
 Conflicts: libblocksruntime-dev (<= 0.5)
-Recommends: clang (>= 8)
+Recommends: clang (>= 8) || clang-8
 Description: development files for the Grand Central Dispatch API
  The libdispatch project consists of the user space implementation of 
  the Grand Central Dispatch API as seen in Mac OS X version 10.6 

--- a/Packaging/Debian/libdispatch-5.1.5/debian/control
+++ b/Packaging/Debian/libdispatch-5.1.5/debian/control
@@ -1,7 +1,7 @@
 Source: libdispatch
 Priority: extra
 Maintainer: Patrick Georgi <patrick@georgi.software>
-Build-Depends: debhelper-compat (= 12), clang, cmake
+Build-Depends: debhelper-compat (= 12), clang-8, cmake
 Standards-Version: 4.5.0
 Section: libs
 Homepage: http://libdispatch.macosforge.org/

--- a/Packaging/Debian/libdispatch-5.1.5/debian/control
+++ b/Packaging/Debian/libdispatch-5.1.5/debian/control
@@ -2,7 +2,7 @@ Source: libdispatch
 Priority: extra
 Maintainer: Patrick Georgi <patrick@georgi.software>
 Build-Depends: debhelper-compat (= 12), clang (>= 8) | clang-8, cmake
-Build-Conflicts: clang (< 8)
+Build-Conflicts: clang (<< 8)
 Standards-Version: 4.5.0
 Section: libs
 Homepage: http://libdispatch.macosforge.org/
@@ -12,7 +12,7 @@ Section: libdevel
 Architecture: any
 Depends: libdispatch0 (= ${binary:Version}), ${misc:Depends}
 Provides: libblocksruntime-dev
-Conflicts: libblocksruntime-dev (<= 0.5)
+Conflicts: libblocksruntime-dev (<= 0.5), clang (<< 8)
 Recommends: clang (>= 8) | clang-8
 Description: development files for the Grand Central Dispatch API
  The libdispatch project consists of the user space implementation of 

--- a/Packaging/Debian/libobjc2-2.1/debian/control
+++ b/Packaging/Debian/libobjc2-2.1/debian/control
@@ -2,7 +2,7 @@ Source: libobjc2
 Priority: optional
 Maintainer: Patrick Georgi <patrick@georgi.software>
 Build-Depends: debhelper-compat (= 12), cmake, clang (>= 8) | clang-8, libdispatch-dev (>= 5)
-Build-Conflicts: clang (< 8)
+Build-Conflicts: clang (<< 8)
 Standards-Version: 4.5.0
 Section: libs
 Homepage: https://github.com/gnustep/libobjc2

--- a/Packaging/Debian/libobjc2-2.1/debian/control
+++ b/Packaging/Debian/libobjc2-2.1/debian/control
@@ -1,7 +1,8 @@
 Source: libobjc2
 Priority: optional
 Maintainer: Patrick Georgi <patrick@georgi.software>
-Build-Depends: debhelper-compat (= 12), cmake, clang (>= 8), libdispatch-dev (>= 5)
+Build-Depends: debhelper-compat (= 12), cmake, clang (>= 8) || clang-8, libdispatch-dev (>= 5)
+Build-Conflicts: clang < 8
 Standards-Version: 4.5.0
 Section: libs
 Homepage: https://github.com/gnustep/libobjc2

--- a/Packaging/Debian/libobjc2-2.1/debian/control
+++ b/Packaging/Debian/libobjc2-2.1/debian/control
@@ -1,7 +1,7 @@
 Source: libobjc2
 Priority: optional
 Maintainer: Patrick Georgi <patrick@georgi.software>
-Build-Depends: debhelper-compat (= 12), cmake, clang-8, libdispatch-dev (>= 5)
+Build-Depends: debhelper-compat (= 12), cmake, clang (>= 8), libdispatch-dev (>= 5)
 Standards-Version: 4.5.0
 Section: libs
 Homepage: https://github.com/gnustep/libobjc2

--- a/Packaging/Debian/libobjc2-2.1/debian/control
+++ b/Packaging/Debian/libobjc2-2.1/debian/control
@@ -1,7 +1,7 @@
 Source: libobjc2
 Priority: optional
 Maintainer: Patrick Georgi <patrick@georgi.software>
-Build-Depends: debhelper-compat (= 12), cmake, clang, libdispatch-dev (>= 5)
+Build-Depends: debhelper-compat (= 12), cmake, clang-8, libdispatch-dev (>= 5)
 Standards-Version: 4.5.0
 Section: libs
 Homepage: https://github.com/gnustep/libobjc2

--- a/Packaging/Debian/libobjc2-2.1/debian/control
+++ b/Packaging/Debian/libobjc2-2.1/debian/control
@@ -1,7 +1,7 @@
 Source: libobjc2
 Priority: optional
 Maintainer: Patrick Georgi <patrick@georgi.software>
-Build-Depends: debhelper-compat (= 12), cmake, clang (>= 8) || clang-8, libdispatch-dev (>= 5)
+Build-Depends: debhelper-compat (= 12), cmake, clang (>= 8) | clang-8, libdispatch-dev (>= 5)
 Build-Conflicts: clang < 8
 Standards-Version: 4.5.0
 Section: libs

--- a/Packaging/Debian/libobjc2-2.1/debian/control
+++ b/Packaging/Debian/libobjc2-2.1/debian/control
@@ -2,7 +2,7 @@ Source: libobjc2
 Priority: optional
 Maintainer: Patrick Georgi <patrick@georgi.software>
 Build-Depends: debhelper-compat (= 12), cmake, clang (>= 8) | clang-8, libdispatch-dev (>= 5)
-Build-Conflicts: clang < 8
+Build-Conflicts: clang (< 8)
 Standards-Version: 4.5.0
 Section: libs
 Homepage: https://github.com/gnustep/libobjc2

--- a/Packaging/Debian/nextspace-0.90+20201106.git68055da9/debian/control
+++ b/Packaging/Debian/nextspace-0.90+20201106.git68055da9/debian/control
@@ -24,7 +24,7 @@ Architecture: all
 Recommends: nextspace-projectcenter.app,
 	    nextspace-gorm.app
 Depends: ${misc:Depends},
-	 xorg
+	 xorg,
 	 nextspace-login.app,
 	 nextspace-workspace.app,
 	 nextspace-timemon.app,

--- a/Packaging/Debian/nextspace-0.90+20201106.git68055da9/debian/control
+++ b/Packaging/Debian/nextspace-0.90+20201106.git68055da9/debian/control
@@ -13,6 +13,7 @@ Package: nextspace-core
 Section: gnustep
 Architecture: all
 Depends: ${misc:Depends},
+	 xorg
 Recommends: plymouth
 Description: System-wide configuration for the NEXTSPACE system
  Default configuration for the shell, gnustep, init system and whatever is

--- a/Packaging/Debian/nextspace-0.90+20201106.git68055da9/debian/control
+++ b/Packaging/Debian/nextspace-0.90+20201106.git68055da9/debian/control
@@ -12,8 +12,7 @@ Vcs-Git: https://github.com/trunkmaster/nextspace
 Package: nextspace-core
 Section: gnustep
 Architecture: all
-Depends: ${misc:Depends},
-	 xorg
+Depends: ${misc:Depends}
 Recommends: plymouth
 Description: System-wide configuration for the NEXTSPACE system
  Default configuration for the shell, gnustep, init system and whatever is
@@ -25,6 +24,7 @@ Architecture: all
 Recommends: nextspace-projectcenter.app,
 	    nextspace-gorm.app
 Depends: ${misc:Depends},
+	 xorg
 	 nextspace-login.app,
 	 nextspace-workspace.app,
 	 nextspace-timemon.app,

--- a/Packaging/Debian/nextspace-base-1.27.0/debian/control
+++ b/Packaging/Debian/nextspace-base-1.27.0/debian/control
@@ -78,6 +78,7 @@ Depends: libnextspace-base1.27 (= ${binary:Version}),
          nextspace-base-runtime (= ${binary:Version}),
          nextspace-make (>= 2.7.0),
          ${misc:Depends}
+Conflicts: clang (< 8)
 Description: GNUstep Base header files and development libraries
  This package contains the header files and static libraries required
  to build applications against the GNUstep Base library.

--- a/Packaging/Debian/nextspace-base-1.27.0/debian/control
+++ b/Packaging/Debian/nextspace-base-1.27.0/debian/control
@@ -78,7 +78,7 @@ Depends: libnextspace-base1.27 (= ${binary:Version}),
          nextspace-base-runtime (= ${binary:Version}),
          nextspace-make (>= 2.7.0),
          ${misc:Depends}
-Conflicts: clang (< 8)
+Conflicts: clang (<< 8)
 Description: GNUstep Base header files and development libraries
  This package contains the header files and static libraries required
  to build applications against the GNUstep Base library.

--- a/Packaging/Debian/nextspace-frameworks-0.90+20201106.git68055da9/debian/control
+++ b/Packaging/Debian/nextspace-frameworks-0.90+20201106.git68055da9/debian/control
@@ -47,7 +47,7 @@ Depends: nextspace-desktopkit0 (= ${binary:Version}),
 	 libnextspace-base-dev,
 	 libnextspace-gui-dev,
 	 ${misc:Depends}
-Conflicts: clang (< 8)
+Conflicts: clang (<< 8)
 Multi-Arch: same
 Description: dummy
  dummy
@@ -78,7 +78,7 @@ Depends: nextspace-soundkit0 (= ${binary:Version}),
 	 libnextspace-base-dev,
 	 libnextspace-gui-dev,
 	 ${misc:Depends}
-Conflicts: clang (< 8)
+Conflicts: clang (<< 8)
 Multi-Arch: same
 Description: dummy
  dummy
@@ -109,7 +109,7 @@ Depends: nextspace-systemkit0 (= ${binary:Version}),
 	 libnextspace-base-dev,
 	 libnextspace-gui-dev,
 	 ${misc:Depends}
-Conflicts: clang (< 8)
+Conflicts: clang (<< 8)
 Multi-Arch: same
 Description: dummy
  dummy

--- a/Packaging/Debian/nextspace-frameworks-0.90+20201106.git68055da9/debian/control
+++ b/Packaging/Debian/nextspace-frameworks-0.90+20201106.git68055da9/debian/control
@@ -47,6 +47,7 @@ Depends: nextspace-desktopkit0 (= ${binary:Version}),
 	 libnextspace-base-dev,
 	 libnextspace-gui-dev,
 	 ${misc:Depends}
+Conflicts: clang (< 8)
 Multi-Arch: same
 Description: dummy
  dummy
@@ -77,6 +78,7 @@ Depends: nextspace-soundkit0 (= ${binary:Version}),
 	 libnextspace-base-dev,
 	 libnextspace-gui-dev,
 	 ${misc:Depends}
+Conflicts: clang (< 8)
 Multi-Arch: same
 Description: dummy
  dummy
@@ -107,6 +109,7 @@ Depends: nextspace-systemkit0 (= ${binary:Version}),
 	 libnextspace-base-dev,
 	 libnextspace-gui-dev,
 	 ${misc:Depends}
+Conflicts: clang (< 8)
 Multi-Arch: same
 Description: dummy
  dummy

--- a/Packaging/Debian/nextspace-gorm.app-1.2.26/debian/control
+++ b/Packaging/Debian/nextspace-gorm.app-1.2.26/debian/control
@@ -31,6 +31,7 @@ Architecture: any
 Depends: libnextspace-gorm1 (= ${binary:Version}),
 	 libnextspace-gui-dev,
 	 ${misc:Depends}
+Conflicts: clang (< 8)
 Description: Clone of the InterfaceBuilder framework - development files
  Gorm, the GNUstep Object Relationship Modeler, is a tool to build GUI
  interfaces for the GNUstep system.  It is a clone of the NeXTStep

--- a/Packaging/Debian/nextspace-gorm.app-1.2.26/debian/control
+++ b/Packaging/Debian/nextspace-gorm.app-1.2.26/debian/control
@@ -31,7 +31,7 @@ Architecture: any
 Depends: libnextspace-gorm1 (= ${binary:Version}),
 	 libnextspace-gui-dev,
 	 ${misc:Depends}
-Conflicts: clang (< 8)
+Conflicts: clang (<< 8)
 Description: Clone of the InterfaceBuilder framework - development files
  Gorm, the GNUstep Object Relationship Modeler, is a tool to build GUI
  interfaces for the GNUstep system.  It is a clone of the NeXTStep

--- a/Packaging/Debian/nextspace-gui-0.28.0+nextspace/debian/control
+++ b/Packaging/Debian/nextspace-gui-0.28.0+nextspace/debian/control
@@ -74,7 +74,7 @@ Depends: libnextspace-gui0.28 (= ${binary:Version}),
          nextspace-gui-runtime (= ${binary:Version}),
          libnextspace-base-dev (>= 1.27),
          ${misc:Depends}
-Conflicts: clang (< 8)
+Conflicts: clang (<< 8)
 Description: GNUstep GUI header files and static libraries
  The GNUstep GUI Library is a powerful library of graphical user interface
  classes written completely in the Objective-C language; the classes are

--- a/Packaging/Debian/nextspace-gui-0.28.0+nextspace/debian/control
+++ b/Packaging/Debian/nextspace-gui-0.28.0+nextspace/debian/control
@@ -74,6 +74,7 @@ Depends: libnextspace-gui0.28 (= ${binary:Version}),
          nextspace-gui-runtime (= ${binary:Version}),
          libnextspace-base-dev (>= 1.27),
          ${misc:Depends}
+Conflicts: clang (< 8)
 Description: GNUstep GUI header files and static libraries
  The GNUstep GUI Library is a powerful library of graphical user interface
  classes written completely in the Objective-C language; the classes are

--- a/Packaging/Debian/nextspace-make-2.7.0/debian/control
+++ b/Packaging/Debian/nextspace-make-2.7.0/debian/control
@@ -3,7 +3,7 @@ Maintainer: Patrick Georgi <patrick@georgi.software>
 Section: gnustep
 Priority: optional
 Build-Depends: debhelper (>= 12),
-               clang (>= 8) || clang-8,
+               clang (>= 8) | clang-8,
                libobjc2-dev,
                pkg-config
 Build-Conflicts: clang < 8
@@ -29,7 +29,7 @@ Package: nextspace-make
 Architecture: all
 Depends: nextspace-common (>= ${source:Version}),
          nextspace-common (<< ${source:Version}.1~),
-         clang (>= 8) || clang-8,
+         clang (>= 8) | clang-8,
          libobjc2-dev,
          libdispatch-dev,
          autotools-dev,

--- a/Packaging/Debian/nextspace-make-2.7.0/debian/control
+++ b/Packaging/Debian/nextspace-make-2.7.0/debian/control
@@ -3,9 +3,10 @@ Maintainer: Patrick Georgi <patrick@georgi.software>
 Section: gnustep
 Priority: optional
 Build-Depends: debhelper (>= 12),
-               clang (>= 8),
+               clang (>= 8) || clang-8,
                libobjc2-dev,
                pkg-config
+Build-Conflicts: clang < 8
 Build-Depends-Indep: texinfo,
                      texlive-base,
                      texlive-latex-base
@@ -28,7 +29,7 @@ Package: nextspace-make
 Architecture: all
 Depends: nextspace-common (>= ${source:Version}),
          nextspace-common (<< ${source:Version}.1~),
-         clang (>= 8),
+         clang (>= 8) || clang-8,
          libobjc2-dev,
          libdispatch-dev,
          autotools-dev,

--- a/Packaging/Debian/nextspace-make-2.7.0/debian/control
+++ b/Packaging/Debian/nextspace-make-2.7.0/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 12),
                clang (>= 8) | clang-8,
                libobjc2-dev,
                pkg-config
-Build-Conflicts: clang (< 8)
+Build-Conflicts: clang (<< 8)
 Build-Depends-Indep: texinfo,
                      texlive-base,
                      texlive-latex-base
@@ -19,7 +19,7 @@ Homepage: http://nextspace.org
 Package: nextspace-common
 Architecture: any
 Depends: ${misc:Depends}, libobjc2-4
-Conflicts: clang (< 8)
+Conflicts: clang (<< 8)
 Provides: nextspace-fslayout-fhs
 Description: Common files for the core GNUstep environment
  This package contains the main GNUstep configuration file, common
@@ -36,7 +36,7 @@ Depends: nextspace-common (>= ${source:Version}),
          autotools-dev,
          ${misc:Depends},
          ${perl:Depends}
-Conflicts: clang (< 8)
+Conflicts: clang (<< 8)
 Description: GNUstep build system
  This package contains the makefiles needed to compile any GNUstep
  software, and the GNUstep Test Framework used by GNUstep packages to

--- a/Packaging/Debian/nextspace-make-2.7.0/debian/control
+++ b/Packaging/Debian/nextspace-make-2.7.0/debian/control
@@ -3,7 +3,7 @@ Maintainer: Patrick Georgi <patrick@georgi.software>
 Section: gnustep
 Priority: optional
 Build-Depends: debhelper (>= 12),
-               clang,
+               clang-8,
                libobjc2-dev,
                pkg-config
 Build-Depends-Indep: texinfo,

--- a/Packaging/Debian/nextspace-make-2.7.0/debian/control
+++ b/Packaging/Debian/nextspace-make-2.7.0/debian/control
@@ -19,6 +19,7 @@ Homepage: http://nextspace.org
 Package: nextspace-common
 Architecture: any
 Depends: ${misc:Depends}, libobjc2-4
+Conflicts: clang (< 8)
 Provides: nextspace-fslayout-fhs
 Description: Common files for the core GNUstep environment
  This package contains the main GNUstep configuration file, common
@@ -35,6 +36,7 @@ Depends: nextspace-common (>= ${source:Version}),
          autotools-dev,
          ${misc:Depends},
          ${perl:Depends}
+Conflicts: clang (< 8)
 Description: GNUstep build system
  This package contains the makefiles needed to compile any GNUstep
  software, and the GNUstep Test Framework used by GNUstep packages to

--- a/Packaging/Debian/nextspace-make-2.7.0/debian/control
+++ b/Packaging/Debian/nextspace-make-2.7.0/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 12),
                clang (>= 8) | clang-8,
                libobjc2-dev,
                pkg-config
-Build-Conflicts: clang < 8
+Build-Conflicts: clang (< 8)
 Build-Depends-Indep: texinfo,
                      texlive-base,
                      texlive-latex-base

--- a/Packaging/Debian/nextspace-make-2.7.0/debian/control
+++ b/Packaging/Debian/nextspace-make-2.7.0/debian/control
@@ -3,7 +3,7 @@ Maintainer: Patrick Georgi <patrick@georgi.software>
 Section: gnustep
 Priority: optional
 Build-Depends: debhelper (>= 12),
-               clang-8,
+               clang (>= 8),
                libobjc2-dev,
                pkg-config
 Build-Depends-Indep: texinfo,
@@ -28,7 +28,7 @@ Package: nextspace-make
 Architecture: all
 Depends: nextspace-common (>= ${source:Version}),
          nextspace-common (<< ${source:Version}.1~),
-         clang,
+         clang (>= 8),
          libobjc2-dev,
          libdispatch-dev,
          autotools-dev,


### PR DESCRIPTION
This PR contains changes to enable building for Debian stable. Aim is a build für Raspbian/armhf.