### PR TITLE
Fix incorrect shell scripting in build scripts

### DIFF
--- a/Packaging/Sources/5_build_libs-base.sh
+++ b/Packaging/Sources/5_build_libs-base.sh
@@ -58,7 +58,7 @@ $CP_CMD ${SOURCES_DIR}/gdomap.service $DEST_DIR/usr/NextSpace/lib/systemd
 $CP_CMD ${SOURCES_DIR}/gdnc.service $DEST_DIR/usr/NextSpace/lib/systemd
 $CP_CMD ${SOURCES_DIR}/gdnc-local.service $DEST_DIR/usr/NextSpace/lib/systemd
 
-if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true"]; then
+if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true" ]; then
 	sudo ldconfig
 	sudo systemctl daemon-reload
 	systemctl status gdomap || sudo systemctl enable /usr/NextSpace/lib/systemd/gdomap.service;

--- a/Packaging/Sources/6_build_libs-gui.sh
+++ b/Packaging/Sources/6_build_libs-gui.sh
@@ -55,7 +55,7 @@ $INSTALL_CMD
 #----------------------------------------
 $CP_CMD ${SOURCES_DIR}/gpbs.service $DEST_DIR/usr/NextSpace/lib/systemd || exit 1
 
-if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true"]; then
+if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true" ]; then
 	sudo ldconfig
 	sudo systemctl daemon-reload || exit 1
 	systemctl status gpbs || sudo systemctl enable /usr/NextSpace/lib/systemd/gpbs.service;

--- a/Packaging/Sources/9_build_Applications.sh
+++ b/Packaging/Sources/9_build_Applications.sh
@@ -75,7 +75,7 @@ sudo ldconfig
 #----------------------------------------
 # Post install
 #----------------------------------------
-if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true"]; then
+if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true" ]; then
 	# Login
 	${ECHO} "Setting up Login window service to run at system startup..."
 	sudo systemctl enable /usr/NextSpace/Apps/Login.app/Resources/loginwindow.service


### PR DESCRIPTION
The `]` is required to be a separate argument in standard POSIX scripting.