### PR TITLE
Clean install of NeXTspace on a pi400 under Ultramarine 40 lite

### DIFF
--- a/Core/os_files/dot_hidden
+++ b/Core/os_files/dot_hidden
@@ -2,13 +2,11 @@ bin
 boot
 dev
 etc
-home
 lib
 lib32
 libx32
 lib64
 lost+found
-media
 mnt
 opt
 proc

--- a/Packaging/Sources/0_build_libdispatch.sh
+++ b/Packaging/Sources/0_build_libdispatch.sh
@@ -10,7 +10,7 @@ if [ "${OS_ID}" = "debian" ] || [ "${OS_ID}" = "ubuntu" ]; then
 	${ECHO} "Debian-based Linux distribution: calling 'apt-get install'."
 	sudo apt-get install -q -y ${BUILD_TOOLS} ${RUNTIME_DEPS} || exit 1
 else
-	if [ "${OS_ID}" = "fedora" ]; then
+	if [ "${OS_ID}" = "fedora" ] || [ "$OS_ID" = "ultramarine" ]; then
 		${ECHO} "No need to build - installing 'libdispatch-devel' from Fedora repository..."
 		sudo dnf -y install libdispatch-devel || exit 1
 		exit 0

--- a/Packaging/Sources/9_build_Applications.sh
+++ b/Packaging/Sources/9_build_Applications.sh
@@ -75,6 +75,7 @@ sudo ldconfig
 #----------------------------------------
 # Post install
 #----------------------------------------
+
 if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true" ]; then
 	# Login
 	${ECHO} "Setting up Login window service to run at system startup..."
@@ -92,3 +93,5 @@ if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true" ]; then
 		fi
 	fi
 fi
+
+. ./rpi_info.sh

--- a/Packaging/Sources/9_build_Applications.sh
+++ b/Packaging/Sources/9_build_Applications.sh
@@ -3,6 +3,8 @@
 . ../environment.sh
 . /etc/profile.d/nextspace.sh
 
+_PWD=`pwd`
+
 #----------------------------------------
 # Install package dependecies
 #----------------------------------------
@@ -79,9 +81,21 @@ sudo ldconfig
 if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true" ]; then
 	# Login
 	${ECHO} "Setting up Login window service to run at system startup..."
+	systemctl --quiet is-active display-manager.service
+	if [ $? -eq 0 ];then
+		${ECHO} "A Display Manager is already running: we must stop it now."
+		sudo systemctl stop display-manager.service
+	fi
+
+	systemctl --quiet is-enabled display-manager.service
+	if [ $? -eq 0 ];then
+		${ECHO} "A display Manager is already set: we must disable it now."
+		sudo systemctl disable display-manager.service
+	fi
+	${ECHO} "Setting up Login window service..."
 	sudo systemctl enable /usr/NextSpace/Apps/Login.app/Resources/loginwindow.service
 	sudo systemctl set-default graphical.target
-	
+
 	# SELinux
 	if [ -f /etc/selinux/config ]; then
 		SELINUX_STATE=`grep "^SELINUX=.*" /etc/selinux/config | awk -F= '{print $2}'`
@@ -94,4 +108,8 @@ if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true" ]; then
 	fi
 fi
 
-. ./rpi_info.sh
+cd ${_PWD} || exit 1
+
+if [ -f ${_PWD}/rpi_info.sh ];then
+	. "${_PWD}/rpi_info.sh"
+fi

--- a/Packaging/Sources/extra/RPI_RESOURCES/screen-resolution_1440.conf
+++ b/Packaging/Sources/extra/RPI_RESOURCES/screen-resolution_1440.conf
@@ -1,0 +1,7 @@
+Section "Screen"
+  Identifier "Screen0"
+  Device "Card0"
+  Subsection "Display"
+    Modes "1440x900"
+  EndSubsection
+EndSection

--- a/Packaging/Sources/extra/RPI_RESOURCES/screen-resolution_1680.conf
+++ b/Packaging/Sources/extra/RPI_RESOURCES/screen-resolution_1680.conf
@@ -1,0 +1,7 @@
+Section "Screen"
+  Identifier "Screen0"
+  Device "Card0"
+  Subsection "Display"
+    Modes "1680x1050"
+  EndSubsection
+EndSection

--- a/Packaging/Sources/rpi_info.sh
+++ b/Packaging/Sources/rpi_info.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+#---------------------------------------
+# Inform about the RPI flickering issue
+#---------------------------------------
+
+ECHO="echo -e"
+
+MACHINE=`uname -m`
+if [ -f /proc/device-tree/model ];then
+	MODEL=`cat /proc/device-tree/model | awk '{print $1}'`
+else
+	MODEL="unkown"
+fi
+if [ -f /proc/device-tree/compatible ];then
+	GPU=`tr -d '\0' < /proc/device-tree/compatible | awk -F, '{print $3}'`
+else
+	GPU="unknown"
+fi
+
+if [ "$MACHINE" = "aarch64" ] && [ "$MODEL" = "Raspberry" ] && [ "$GPU" = "bcm2711" ];then
+	clear
+	PWD=`pwd`
+	${ECHO} "The current computer is a ${MODEL} with a VideoCore 3D unit GPU."
+	${ECHO} "It could happen that your HD display might flicker."
+	${ECHO} "Do NOT reboot until You tested the 'Workspace' load..."
+
+	if ! [ -f $HOME/.xinitrc ];then
+		${ECHO} "But You must set up the user home before:"
+		${ECHO} "\t sudo ./setup_user.sh"
+		${ECHO} "\t ./setup_user.sh"
+	fi
+
+	${ECHO} "And then the test:"
+	${ECHO} "\t cd && startx"
+
+	${ECHO}
+	${ECHO} "If it is NOT ok, open the 'Preferences' (clock icon) "
+	${ECHO} " and try a lower resolution for the display. Note it, logout, "
+	${ECHO} "\t cd ${PWD}/extra/RPI_RESOURCES"
+	${ECHO} "edit and adapt the 'screen-resolution.conf',"
+	${ECHO} "Then copy it to '/etc/X11/xorg.conf.d' folder."
+	${ECHO}
+	${ECHO} "Test again with 'startx'. If it is OK now,"
+fi
+
+${ECHO} "You need to reboot to use the Login Panel."

--- a/Packaging/Sources/rpi_info.sh
+++ b/Packaging/Sources/rpi_info.sh
@@ -4,7 +4,14 @@
 # Inform about the RPI flickering issue
 #---------------------------------------
 
-ECHO="echo -e"
+if [ -z "${ECHO}" ];then
+	ECHO="/usr/bin/echo -e"
+fi
+
+if [ -z "$_PWD" ];then
+	${ECHO} "You should not run the script $0 by itself."
+	exit 1
+fi
 
 MACHINE=`uname -m`
 if [ -f /proc/device-tree/model ];then
@@ -19,29 +26,33 @@ else
 fi
 
 if [ "$MACHINE" = "aarch64" ] && [ "$MODEL" = "Raspberry" ] && [ "$GPU" = "bcm2711" ];then
-	clear
-	PWD=`pwd`
+
+	${ECHO} "============================================="
 	${ECHO} "The current computer is a ${MODEL} with a VideoCore 3D unit GPU."
 	${ECHO} "It could happen that your HD display might flicker."
 	${ECHO} "Do NOT reboot until You tested the 'Workspace' load..."
 
 	if ! [ -f $HOME/.xinitrc ];then
+		${ECHO} "---"
 		${ECHO} "But You must set up the user home before:"
 		${ECHO} "\t sudo ./setup_user.sh"
 		${ECHO} "\t ./setup_user.sh"
+		${ECHO} "---"
 	fi
 
-	${ECHO} "And then the test:"
+	${ECHO} "Then, let's run this test:"
 	${ECHO} "\t cd && startx"
 
-	${ECHO}
+	${ECHO} "---"
 	${ECHO} "If it is NOT ok, open the 'Preferences' (clock icon) "
-	${ECHO} " and try a lower resolution for the display. Note it, logout, "
-	${ECHO} "\t cd ${PWD}/extra/RPI_RESOURCES"
+	${ECHO} " and try a lower resolution for the display in the tab"
+	${ECHO} "'Display Preferences'. Note it, logout, "
+	${ECHO} "\t cd ${_PWD}/extra/RPI_RESOURCES"
 	${ECHO} "edit and adapt the 'screen-resolution.conf',"
-	${ECHO} "Then copy it to '/etc/X11/xorg.conf.d' folder."
-	${ECHO}
+	${ECHO} "Then copy it into the '/etc/X11/xorg.conf.d' folder."
+	${ECHO} "---"
 	${ECHO} "Test again with 'startx'. If it is OK now,"
+	${ECHO} "============================================="
 fi
 
 ${ECHO} "You need to reboot to use the Login Panel."

--- a/Packaging/environment.sh
+++ b/Packaging/environment.sh
@@ -139,7 +139,7 @@ else
   ${ECHO} "Using linker:\tGold"
 fi
 # Compiler
-if [ "$OS_ID" = "fedora" ] || [ "$OS_LIKE" = "rhel" ] || [ "$OS_ID" = "debian" ] || [ "$OS_ID" = "ubuntu" ]; then
+if [ "$OS_ID" = "fedora" ] || [ "$OS_LIKE" = "rhel" ] || [ "$OS_ID" = "debian" ] || [ "$OS_ID" = "ubuntu" ] || [ "$OS_ID" = "ultramarine" ]; then
   which clang 2>&1 > /dev/null || `echo "No clang compiler found. Please install clang package."; exit 1`
   C_COMPILER=`which clang`
   which clang++ 2>&1 > /dev/null || `echo "No clang++ compiler found. Please install clang++ package."; exit 1`

--- a/Packaging/functions.sh
+++ b/Packaging/functions.sh
@@ -133,7 +133,7 @@ prepare_environment()
             sudo dnf config-manager --set-enabled crb
             sudo dnf -y install clang
         else
-            if [ "$OS_ID" = "fedora" ];then
+            if [ "$OS_ID" = "fedora" ] || [ "$OS_ID" = "ultramarine" ];then
                 sudo dnf -y install clang
             else
                 print_H2 ">>>>> Can't find /etc/os-release - this OS is unsupported."


### PR DESCRIPTION
Ultramarine is a Fedora like distro, easy to install on the PIs, because it provides an official image to dot it.
No worry with dependencies. ;-)
So it is a good target to install NeXTspace on, and compatible with master code.

This was successfully tested and installed on a pi400 rev.1, with a 60x34cm monitor (Acer ACR model 57e) wired at the HDMI-1 port. The higher suppoted resolution may be1680x1050. I am currently using 1440x900.

I preserved the C.UTF-8 locale at building stage and after. I set the keyboard to french alt (oss) layer and variant.
The language was set with `Preferences.app`.

It was only necessary to make little adjustemnts to comply with $OS_ID ("ultramarine") var on a few scripts.

A post-install script was also added to inform about how to set the screen resolution for `Login.app` if necessary due to the known HD issue with the VideoCore VI 3D GPU unit.