### PR TITLE
New DBus integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Frameworks/DBusKit"]
-	path = Frameworks/DBusKit
-	url = https://github.com/gnustep/libs-dbuskit

--- a/Applications/Login/Controller.h
+++ b/Applications/Login/Controller.h
@@ -70,9 +70,6 @@ extern LoginExitCode panelExitCode;
   int xScreen;
   Window xPanelWindow;
 
-  // OSEScreen	       *screen;
-  OSEPower *systemPower;
-
   // Preferences
   OSEDefaults *prefs;
 
@@ -91,6 +88,9 @@ extern LoginExitCode panelExitCode;
   NSTimer *busyTimer;
   NSTimer *rrTimer;
 }
+
+@property (readonly) OSEScreen *systemScreen;
+@property (readonly) OSEPower *systemPower;
 
 - (void)displayHostname;
 - (void)clearFields;

--- a/Applications/Login/Controller.h
+++ b/Applications/Login/Controller.h
@@ -62,6 +62,8 @@ extern LoginExitCode panelExitCode;
   IBOutlet id          shutDownBtn;
   IBOutlet id          restartBtn;
 
+  BOOL isWindowActive;
+  
   // X resources
   Display              *xDisplay;
   Window               xRootWindow;

--- a/Applications/Login/Controller.h
+++ b/Applications/Login/Controller.h
@@ -40,10 +40,10 @@
 // 11 - shutdown
 // 12 - reboot
 typedef enum {
-  QuitExitCode     = 128,
+  QuitExitCode = 128,
   ShutdownExitCode = 129,
-  RebootExitCode   = 130,
-  UpdateExitCode   = 131
+  RebootExitCode = 130,
+  UpdateExitCode = 131
 } LoginExitCode;
 
 extern LoginExitCode panelExitCode;
@@ -53,43 +53,43 @@ extern LoginExitCode panelExitCode;
 @interface Controller : NSObject
 {
   IBOutlet LoginWindow *window;
-  IBOutlet id          hostnameField;
-  IBOutlet id          fieldsImage;
-  IBOutlet id          fieldsLabelImage;
-  IBOutlet id          panelImageView;
-  IBOutlet id          userName;
-  IBOutlet id          password;
-  IBOutlet id          shutDownBtn;
-  IBOutlet id          restartBtn;
+  IBOutlet id hostnameField;
+  IBOutlet id fieldsImage;
+  IBOutlet id fieldsLabelImage;
+  IBOutlet id panelImageView;
+  IBOutlet id userName;
+  IBOutlet id password;
+  IBOutlet id shutDownBtn;
+  IBOutlet id restartBtn;
 
   BOOL isWindowActive;
-  
+
   // X resources
-  Display              *xDisplay;
-  Window               xRootWindow;
-  int                  xScreen;
-  Window               xPanelWindow;
+  Display *xDisplay;
+  Window xRootWindow;
+  int xScreen;
+  Window xPanelWindow;
 
   // OSEScreen	       *screen;
-  OSEPower             *systemPower;
+  OSEPower *systemPower;
 
   // Preferences
-  OSEDefaults           *prefs;
+  OSEDefaults *prefs;
 
   // User sessions
-  NSArray              *mainThreadPorts;
-  NSMutableDictionary  *userSessions;
+  NSArray *mainThreadPorts;
+  NSMutableDictionary *userSessions;
 
-  pam_handle_t         *PAM_handle;
+  pam_handle_t *PAM_handle;
 
   // Error panel
   NXTAlert *alert;
   NSScrollView *consoleLogView;
 
   // Busy cursor
-  XcursorAnimate       *busy_cursor;
-  NSTimer              *busyTimer;
-  NSTimer              *rrTimer;
+  XcursorAnimate *busy_cursor;
+  NSTimer *busyTimer;
+  NSTimer *rrTimer;
 }
 
 - (void)displayHostname;
@@ -123,7 +123,7 @@ extern LoginExitCode panelExitCode;
 
 @interface Controller (Preferences)
 
-- (NSString*)lastLoggedInUser;
+- (NSString *)lastLoggedInUser;
 - (void)setLastLoggedInUser:(NSString *)username;
 
 @end
@@ -138,4 +138,3 @@ extern LoginExitCode panelExitCode;
 - (void)openSessionWithHandle:(pam_handle_t *)handle;
 
 @end
-

--- a/Applications/Login/Controller.m
+++ b/Applications/Login/Controller.m
@@ -239,14 +239,14 @@ static int catchXErrors(Display *dpy, XErrorEvent *event) { return 0; }
 
 - (void)setRootWindowBackground
 {
+  OSEScreen *screen = [OSEScreen new];
   XSetWindowAttributes winattrs;
 
   winattrs.cursor = XCreateFontCursor(xDisplay, XC_left_ptr);
   XChangeWindowAttributes(xDisplay, xRootWindow, CWCursor, &winattrs);
 
-  [[OSEScreen sharedScreen] setBackgroundColorRed:83.0 / 255.0
-                                            green:83.0 / 255.0
-                                             blue:116.0 / 255.0];
+  [screen setBackgroundColorRed:83.0 / 255.0 green:83.0 / 255.0 blue:116.0 / 255.0];
+  [screen release];
 }
 
 - (void)setWindowVisible:(BOOL)flag
@@ -301,7 +301,7 @@ static int catchXErrors(Display *dpy, XErrorEvent *event) { return 0; }
 - (void)lidDidChange:(NSNotification *)aNotif
 {
   OSEDisplay *builtinDisplay = nil;
-  OSEScreen *screen = [OSEScreen sharedScreen];
+  OSEScreen  *screen = [OSEScreen new];
   BOOL isLidClosed = NO;
 
   NSLog(@"lidDidChange: %@", aNotif.userInfo);
@@ -343,7 +343,7 @@ static int catchXErrors(Display *dpy, XErrorEvent *event) { return 0; }
     }
   }
 
-  // [screen release];
+  [screen release];
 }
 
 // --- Busy cursor
@@ -637,6 +637,12 @@ int ConversationFunction(int num_msg, const struct pam_message **msg, struct pam
              name:@"LoginDefaultsDidChangeNotification"
            object:@"Preferences"];
   NSLog(@"appDidFinishLaunch: end");
+}
+
+- (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)sender
+{
+  NSLog(@"ApplicationShouldTerminate");
+  return NSTerminateNow;
 }
 
 - (void)defaultsDidChange:(NSNotification *)notif

--- a/Applications/Login/Controller.m
+++ b/Applications/Login/Controller.m
@@ -684,6 +684,7 @@ int ConversationFunction(int num_msg, const struct pam_message **msg, struct pam
       return;
     } else if ([user isEqualToString:@"terminate"]) {
       NSLog(@"Application will quit");
+      panelExitCode = QuitExitCode;
       [NSApp terminate:self];  // Equivalent to "Quit" menu item
       return;
     } else if ([user isEqualToString:@"shake"]) {  // for testing

--- a/Applications/Login/Controller.m
+++ b/Applications/Login/Controller.m
@@ -301,7 +301,7 @@ static int catchXErrors(Display *dpy, XErrorEvent *event) { return 0; }
 - (void)lidDidChange:(NSNotification *)aNotif
 {
   OSEDisplay *builtinDisplay = nil;
-  OSEScreen *screen = [OSEScreen new];
+  OSEScreen *screen = [OSEScreen sharedScreen];
   BOOL isLidClosed = NO;
 
   NSLog(@"lidDidChange: %@", aNotif.userInfo);
@@ -343,7 +343,7 @@ static int catchXErrors(Display *dpy, XErrorEvent *event) { return 0; }
     }
   }
 
-  [screen release];
+  // [screen release];
 }
 
 // --- Busy cursor

--- a/Applications/Login/Controller.m
+++ b/Applications/Login/Controller.m
@@ -27,7 +27,7 @@
 #import <sys/ioctl.h>
 
 #ifdef __FreeBSD__
-#import <sys/consio.h> // for changing VT
+#import <sys/consio.h>  // for changing VT
 #endif
 
 #import <SystemKit/OSEDisplay.h>
@@ -91,14 +91,12 @@ LoginExitCode panelExitCode;
     return;
   }
 
-  session = [[UserSession alloc] initWithOwner:self
-                                           name:user
-                                       defaults:(NSDictionary *)prefs];
+  session = [[UserSession alloc] initWithOwner:self name:user defaults:(NSDictionary *)prefs];
   [session readSessionScript];
   [session addObserver:self
-             forKeyPath:@"isRunning"
-                options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld
-                context:session];
+            forKeyPath:@"isRunning"
+               options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld
+               context:session];
   [userSessions setObject:session forKey:user];  // remember user session
   [session release];
 
@@ -148,7 +146,7 @@ LoginExitCode panelExitCode;
   if (session.isRunning == NO) {
     [userSessions removeObjectForKey:session.userName];
     pam_end(PAM_handle, 0);
-  
+
     // TODO: actually this doesn't make sense because no multiple session handling
     // implemented yet. Leave it for the future.
     if ([[userSessions allKeys] count] == 0) {
@@ -226,16 +224,13 @@ LoginExitCode panelExitCode;
 //=============================================================================
 @implementation Controller (XWindowSystem)
 
-static int catchXErrors(Display* dpy, XErrorEvent* event)
-{
-  return 0;
-}
+static int catchXErrors(Display *dpy, XErrorEvent *event) { return 0; }
 
 // --- General
 - (void)initXApp
 {
   GSDisplayServer *xServer = GSCurrentServer();
-  
+
   xDisplay = [xServer serverDevice];
   xScreen = DefaultScreen(xDisplay);
   xRootWindow = RootWindow(xDisplay, xScreen);
@@ -248,7 +243,7 @@ static int catchXErrors(Display* dpy, XErrorEvent* event)
 
   winattrs.cursor = XCreateFontCursor(xDisplay, XC_left_ptr);
   XChangeWindowAttributes(xDisplay, xRootWindow, CWCursor, &winattrs);
-  
+
   [[OSEScreen sharedScreen] setBackgroundColorRed:83.0 / 255.0
                                             green:83.0 / 255.0
                                              blue:116.0 / 255.0];
@@ -262,14 +257,11 @@ static int catchXErrors(Display* dpy, XErrorEvent* event)
     [window center];
     [window makeKeyAndOrderFront:self];
 
-    XSetInputFocus(xDisplay, xPanelWindow, RevertToPointerRoot, 
-                   CurrentTime);
-    XGrabKeyboard(xDisplay, xPanelWindow, False, GrabModeAsync, 
-                  GrabModeAsync, CurrentTime);
-  }
-  else {
+    XSetInputFocus(xDisplay, xPanelWindow, RevertToPointerRoot, CurrentTime);
+    XGrabKeyboard(xDisplay, xPanelWindow, False, GrabModeAsync, GrabModeAsync, CurrentTime);
+  } else {
     XUngrabKeyboard(xDisplay, CurrentTime);
-    [window orderOut:self]; // to prevent altert panels to show window
+    [window orderOut:self];  // to prevent altert panels to show window
     XWithdrawWindow(xDisplay, xPanelWindow, xScreen);
   }
   XFlush(xDisplay);
@@ -277,10 +269,10 @@ static int catchXErrors(Display* dpy, XErrorEvent* event)
 
 - (void)closeAllXClients
 {
-  Window            dummywindow;
-  Window*           children;
-  unsigned int      nchildren = 0;
-  unsigned int      i;
+  Window dummywindow;
+  Window *children;
+  unsigned int nchildren = 0;
+  unsigned int i;
   XWindowAttributes attr;
 
   XSync(xDisplay, 0);
@@ -311,7 +303,7 @@ static int catchXErrors(Display* dpy, XErrorEvent* event)
   OSEDisplay *builtinDisplay = nil;
   OSEScreen *screen = [OSEScreen new];
   BOOL isLidClosed = NO;
-  
+
   NSLog(@"lidDidChange: %@", aNotif.userInfo);
 
   if (aNotif.userInfo) {
@@ -380,15 +372,13 @@ static int catchXErrors(Display* dpy, XErrorEvent* event)
 - (void)destroyBusyCursor
 {
   Cursor arrow_cursor;
-  
-  if (busyTimer != nil &&
-      [busyTimer isKindOfClass:[NSTimer class]] &&
-      [busyTimer isValid]) {
+
+  if (busyTimer != nil && [busyTimer isKindOfClass:[NSTimer class]] && [busyTimer isValid]) {
     [busyTimer invalidate];
   }
   XcursorAnimateDestroy(busy_cursor);
   busy_cursor = NULL;
-  
+
   arrow_cursor = XCreateFontCursor(xDisplay, XC_left_ptr);
   XDefineCursor(xDisplay, xRootWindow, arrow_cursor);
   XDefineCursor(xDisplay, xPanelWindow, arrow_cursor);
@@ -400,10 +390,10 @@ static int catchXErrors(Display* dpy, XErrorEvent* event)
   Cursor xcursor = XcursorAnimateNext(busy_cursor);
 
   fprintf(stderr, "[Animate] cursor %i\n", busy_cursor->sequence);
-  
+
   XDefineCursor(xDisplay, xRootWindow, xcursor);
   XDefineCursor(xDisplay, xPanelWindow, xcursor);
-  
+
   XFlush(xDisplay);
 }
 
@@ -419,13 +409,12 @@ static int catchXErrors(Display* dpy, XErrorEvent* event)
   if ([[prefs objectForKey:@"RememberLastLoggedInUser"] integerValue] == 1) {
     return [prefs objectForKey:@"LastLoggedInUser"];
   }
-  
+
   return nil;
 }
 
 - (void)setLastLoggedInUser:(NSString *)username
 {
-  
   [prefs setObject:username == nil ? @"" : [NSString stringWithString:username]
             forKey:@"LastLoggedInUser"];
 }
@@ -437,10 +426,8 @@ static int catchXErrors(Display* dpy, XErrorEvent* event)
 //=============================================================================
 @implementation Controller (PAMAuth)
 
-int ConversationFunction(int num_msg, 
-    			 const struct pam_message ** msg, 
-    			 struct pam_response ** resp, 
-    			 void * appdata_ptr)
+int ConversationFunction(int num_msg, const struct pam_message **msg, struct pam_response **resp,
+                         void *appdata_ptr)
 {
   if (num_msg != 1) {
     NSLog(@"PAM: 0 messages was sent to conversation function.");
@@ -452,11 +439,10 @@ int ConversationFunction(int num_msg,
   if (!*resp) {
     NSLog(@"PAM: out of memory, terminating");
     exit(0);
-  }
-  else {
+  } else {
     memset(*resp, 0, sizeof(struct pam_response));
   }
-  
+
   (*resp)[0].resp = strdup([[[NSApp delegate] password] cString]);
   (*resp)[0].resp_retcode = 0;
 
@@ -472,21 +458,21 @@ int ConversationFunction(int num_msg,
     NSLog(@"Failed to initialize PAM");
     return NO;
   }
-  
+
   NS_DURING
-    {
-      [self authenticateWithHandle:PAM_handle];
-      [self establishAccountManagementWithHandle:PAM_handle];
-      [self establishCredentialsWithHandle:PAM_handle];
-      [self setLastLoggedInUser:user];
-      [self openSessionWithHandle:PAM_handle];
-      return YES;
-    }
+  {
+    [self authenticateWithHandle:PAM_handle];
+    [self establishAccountManagementWithHandle:PAM_handle];
+    [self establishCredentialsWithHandle:PAM_handle];
+    [self setLastLoggedInUser:user];
+    [self openSessionWithHandle:PAM_handle];
+    return YES;
+  }
   NS_HANDLER
-    {
-      pam_end(PAM_handle, 0);
-      return NO;
-    }
+  {
+    pam_end(PAM_handle, 0);
+    return NO;
+  }
   NS_ENDHANDLER
 }
 
@@ -499,7 +485,7 @@ int ConversationFunction(int num_msg,
 - (void)authenticateWithHandle:(pam_handle_t *)handle
 {
   int ret;
-  
+
   if ((ret = pam_authenticate(handle, 0)) != PAM_SUCCESS) {
     NSLog(@"PAM error: %s", pam_strerror(handle, ret));
     [NSException raise:PAMAuthenticationException format:nil];
@@ -508,8 +494,7 @@ int ConversationFunction(int num_msg,
 
 - (void)establishAccountManagementWithHandle:(pam_handle_t *)handle
 {
-  switch (pam_acct_mgmt(handle, 0))
-    {
+  switch (pam_acct_mgmt(handle, 0)) {
     case PAM_ACCT_EXPIRED:
       NSLog(@"PAM: Account expired.");
       [NSException raise:PAMAccountExpiredException format:nil];
@@ -522,13 +507,13 @@ int ConversationFunction(int num_msg,
       NSLog(@"PAM: Permission denied.");
       [NSException raise:PAMPermissionDeniedException format:nil];
       break;
-    case PAM_USER_UNKNOWN: // hide the fact that the user is unknown
+    case PAM_USER_UNKNOWN:  // hide the fact that the user is unknown
       NSLog(@"PAM: User unknown.");
       [NSException raise:PAMAuthenticationException format:nil];
       break;
     default:
       break;
-    }
+  }
 }
 
 - (void)establishCredentialsWithHandle:(pam_handle_t *)handle
@@ -553,7 +538,7 @@ int ConversationFunction(int num_msg,
 
 - (void)awakeFromNib
 {
-  NSRect   rect;
+  NSRect rect;
   NSString *user;
 
   if (userSessions) {
@@ -569,7 +554,7 @@ int ConversationFunction(int num_msg,
   rect = [window frame];
   rect.size = [[panelImageView image] size];
   [window setFrame:rect display:NO];
-  
+
   [shutDownBtn setRefusesFirstResponder:YES];
   [restartBtn setRefusesFirstResponder:YES];
   [fieldsImage setRefusesFirstResponder:YES];
@@ -588,7 +573,6 @@ int ConversationFunction(int num_msg,
   }
 
   [password setEchosBullets:NO];
-            
 
   panelExitCode = 0;
   NSLog(@"awakeFromNib: end");
@@ -596,13 +580,13 @@ int ConversationFunction(int num_msg,
 
 - (void)displayHostname
 {
-  char     hostname[256], displayname[256];
-  int      namelen = 256, index = 0;
+  char hostname[256], displayname[256];
+  int namelen = 256, index = 0;
   NSString *host_name = nil;
 
   // Initialize hostname
-  gethostname( hostname, namelen );
-  for(index = 0; index < 256 && hostname[index] != '.'; index++) {
+  gethostname(hostname, namelen);
+  for (index = 0; index < 256 && hostname[index] != '.'; index++) {
     displayname[index] = hostname[index];
   }
   displayname[index] = 0;
@@ -613,8 +597,7 @@ int ConversationFunction(int num_msg,
     if ([hostnameField superview] != nil) {
       [hostnameField removeFromSuperview];
     }
-  }
-  else if ([hostnameField superview] == nil) {
+  } else if ([hostnameField superview] == nil) {
     [panelImageView addSubview:hostnameField];
   }
 }
@@ -625,7 +608,7 @@ int ConversationFunction(int num_msg,
 
   // Initialize X resources
   [self initXApp];
-  
+
   NSLog(@"appDidFinishLaunch: before showWindow");
   // Show login window
   [self setWindowVisible:YES];
@@ -638,23 +621,21 @@ int ConversationFunction(int num_msg,
   //   }
   // NSConnection *conn = [NSConnection defaultConnection];
   // [conn registerName:@"loginwindow"];
-  
+
   // Laptop lid events handling
   systemPower = [OSEPower new];
   [systemPower startEventsMonitor];
-  [[NSNotificationCenter defaultCenter]
-                  addObserver:self
-                     selector:@selector(lidDidChange:)
-                         name:OSEPowerLidDidChangeNotification
-                       object:systemPower];
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(lidDidChange:)
+                                               name:OSEPowerLidDidChangeNotification
+                                             object:systemPower];
 
   // Defaults
-  [[NSDistributedNotificationCenter
-     notificationCenterForType:GSPublicNotificationCenterType]
-    addObserver:self
-       selector:@selector(defaultsDidChange:)
-           name:@"LoginDefaultsDidChangeNotification"
-         object:@"Preferences"];
+  [[NSDistributedNotificationCenter notificationCenterForType:GSPublicNotificationCenterType]
+      addObserver:self
+         selector:@selector(defaultsDidChange:)
+             name:@"LoginDefaultsDidChangeNotification"
+           object:@"Preferences"];
   NSLog(@"appDidFinishLaunch: end");
 }
 
@@ -674,7 +655,7 @@ int ConversationFunction(int num_msg,
   NSString *user = [[NSString alloc] initWithString:[userName stringValue]];
 
   // [self setBusyCursor];
-  
+
   NSLog(@"[Controller authenticate:] userName: %@", user);
 
   if (sender == userName) {
@@ -693,19 +674,16 @@ int ConversationFunction(int num_msg,
     } else if ([user isEqualToString:@"quit"]) {
       NSLog(@"Application will be stopped");
       panelExitCode = QuitExitCode;
-      [NSApp stop:self]; // Go out of run loop
+      [NSApp stop:self];  // Go out of run loop
       return;
-    }
-    else if ([user isEqualToString:@"terminate"]) {
+    } else if ([user isEqualToString:@"terminate"]) {
       NSLog(@"Application will quit");
-      [NSApp terminate:self]; // Equivalent to "Quit" menu item
+      [NSApp terminate:self];  // Equivalent to "Quit" menu item
       return;
-    }
-    else if ([user isEqualToString:@"shake"]) { // for testing
+    } else if ([user isEqualToString:@"shake"]) {  // for testing
       [window shakePanel:xPanelWindow onDisplay:xDisplay];
       return;
-    }
-    else {
+    } else {
       [window makeFirstResponder:password];
       return;
     }
@@ -716,11 +694,10 @@ int ConversationFunction(int num_msg,
     [self setWindowVisible:NO];
     isWindowActive = NO;
     [self openSessionForUser:user];
-  }
-  else {
+  } else {
     [window shakePanel:xPanelWindow onDisplay:xDisplay];
   }
-  
+
   [self clearFields];
   // [self destroyBusyCursor];
   [user release];
@@ -731,22 +708,20 @@ int ConversationFunction(int num_msg,
   NSInteger alertResult;
 
   NSLog(@"[Controller restart] initial exit code: %d", panelExitCode);
-  
+
   // No need to ask user if exit code already defined.
   if (panelExitCode == 0) {
-    alertResult = NXTRunAlertPanel(_(@"Restart"),
-                                   _(@"Do you really want to restart the computer?"),
+    alertResult = NXTRunAlertPanel(_(@"Restart"), _(@"Do you really want to restart the computer?"),
                                    _(@"Restart"), _(@"Cancel"), nil);
-  
+
     if (alertResult == NSAlertDefaultReturn) {
       panelExitCode = RebootExitCode;
     }
   }
 
   if (panelExitCode == RebootExitCode) {
-    NSLog(@"[Controller] restart: application will be stopped with exit code: %d",
-          panelExitCode);
-    [NSApp stop:self]; // Go out of run loop
+    NSLog(@"[Controller] restart: application will be stopped with exit code: %d", panelExitCode);
+    [NSApp stop:self];  // Go out of run loop
   }
 }
 
@@ -755,22 +730,20 @@ int ConversationFunction(int num_msg,
   NSInteger alertResult;
 
   NSLog(@"[Controller shutDown] initial exit code: %d", panelExitCode);
-  
+
   // Ask user to verify his choice
   if (panelExitCode == 0) {
-    alertResult = NXTRunAlertPanel(_(@"Power"),
-                                   _(@"Do you really want to turn off the computer?"),
+    alertResult = NXTRunAlertPanel(_(@"Power"), _(@"Do you really want to turn off the computer?"),
                                    _(@"Turn it off"), _(@"Cancel"), nil);
-  
+
     if (alertResult == NSAlertDefaultReturn) {
       panelExitCode = ShutdownExitCode;
     }
   }
-  
+
   if (panelExitCode == ShutdownExitCode) {
-    NSLog(@"[Controller] shutDown: application will be stopped with exit code: %d",
-          panelExitCode);
-    [NSApp stop:self]; // Go out of run loop
+    NSLog(@"[Controller] shutDown: application will be stopped with exit code: %d", panelExitCode);
+    [NSApp stop:self];  // Go out of run loop
   }
 }
 
@@ -779,16 +752,14 @@ int ConversationFunction(int num_msg,
   NSString *user = [self lastLoggedInUser];
 
   [password setStringValue:@""];
-  
-  if (user && [user length] > 0) {  
+
+  if (user && [user length] > 0) {
     [userName setStringValue:user];
     [window makeFirstResponder:password];
-  }
-  else {
+  } else {
     [userName setStringValue:@""];
     [window makeFirstResponder:userName];
   }
 }
 
 @end
-

--- a/Applications/Login/GNUmakefile
+++ b/Applications/Login/GNUmakefile
@@ -29,13 +29,12 @@ Preferences
 # Resource files
 #
 Login_RESOURCE_FILES = \
-Resources/Login.gorm \
-Resources/ConsoleLog.gorm \
-Resources/loginwindow.tiff \
-Resources/Login \
-Resources/Login.user \
-Resources/loginwindow.service \
-Preferences/Login.preferences
+	Resources/Login.gorm \
+	Resources/ConsoleLog.gorm \
+	Resources/loginwindow.tiff \
+	Resources/Login \
+	Resources/Login.user \
+	Preferences/Login.preferences
 
 
 #

--- a/Applications/Login/GNUmakefile.postamble
+++ b/Applications/Login/GNUmakefile.postamble
@@ -12,13 +12,15 @@
 # before-install::
   
 # Things to do after installing
-# after-install::
+after-install::
+	@ cp Resources/loginwindow.service /usr/NextSpace/lib/systemd
 
 # Things to do before uninstalling
 # before-uninstall::
 
 # Things to do after uninstalling
-# after-uninstall::
+after-uninstall::
+	@ /usr/NextSpace/lib/systemd/loginwindow.service
 
 # Things to do before cleaning
 # before-clean::

--- a/Applications/Login/GNUmakefile.preamble
+++ b/Applications/Login/GNUmakefile.preamble
@@ -12,7 +12,7 @@ ADDITIONAL_OBJCFLAGS += -DHAVE_PAM -DWITH_UPOWER -Wno-typedef-redefinition -fno-
 ADDITIONAL_CFLAGS += 
 
 # Additional flags to pass to the linker
-ADDITIONAL_LDFLAGS += -lpam -lX11 -lSystemKit -lDesktopKit -ldispatch -lXcursor -lXrandr
+ADDITIONAL_LDFLAGS += -lpam -lX11 -lXcursor -lXrandr -ldispatch -lSystemKit -lDesktopKit
 #-lXmu -lXxf86vm 
 
 # Additional include directories the compiler should search

--- a/Applications/Login/LoginWindow.h
+++ b/Applications/Login/LoginWindow.h
@@ -25,7 +25,7 @@
 @interface LoginWindow : NSWindow
 {
 }
-- (void)shakePanel:(Window)panel onDisplay:(Display*)dpy;
-- (void)shrinkPanel:(Window)panel onDisplay:(Display*)dpy;
+- (void)shakePanel:(Window)panel onDisplay:(Display *)dpy;
+- (void)shrinkPanel:(Window)panel onDisplay:(Display *)dpy;
 
 @end

--- a/Applications/Login/LoginWindow.m
+++ b/Applications/Login/LoginWindow.m
@@ -81,34 +81,32 @@
   NSRect windowRect = [self frame];
   NSPoint newOrigin;
 
-  NSLog(@"center");
+  NSDebugLLog(@"Screen", @"center");
 
   // Get NEXTSPACE display rect
-  // screen = [OSEScreen new];
   if (screen != nil) {
     if ([[screen activeDisplays] count] > 0) {
       display = [screen mainDisplay];
       if (!display) {
-        NSLog(@"No main display - using first active.");
+        NSDebugLLog(@"Screen", @"No main display - using first active.");
         display = [[screen activeDisplays] objectAtIndex:0];
       }
     } else if ([[screen connectedDisplays] count] > 0) {
-      NSLog(@"No active displays left - activating first connected.");
+      NSDebugLLog(@"Screen", @"No active displays left - activating first connected.");
       display = [[screen connectedDisplays] objectAtIndex:0];
       [screen activateDisplay:display];
     }
     screenSize = [screen sizeInPixels];
     displayRect = [display frame];
 
-    NSLog(@"Screen size   : %4.0f x %4.0f", screenSize.width, screenSize.height);
+    NSDebugLLog(@"Screen", @"Screen size   : %4.0f x %4.0f", screenSize.width, screenSize.height);
   }
-  // [screen release];
 
-  NSLog(@"Display frame : %4.0f x %4.0f  (%4.0f, %4.0f)", displayRect.size.width,
-        displayRect.size.height, displayRect.origin.x, displayRect.origin.y);
+  NSDebugLLog(@"Screen", @"Display frame : %4.0f x %4.0f  (%4.0f, %4.0f)", displayRect.size.width,
+              displayRect.size.height, displayRect.origin.x, displayRect.origin.y);
 
-  NSLog(@"Window frame  : %4.0f x %4.0f  (%4.0f, %4.0f)", windowRect.size.width,
-        windowRect.size.height, windowRect.origin.x, windowRect.origin.y);
+  NSDebugLLog(@"Screen", @"Window frame  : %4.0f x %4.0f  (%4.0f, %4.0f)", windowRect.size.width,
+              windowRect.size.height, windowRect.origin.x, windowRect.origin.y);
 
   // Calculate the new position of the window on display.
   newOrigin.x = displayRect.size.width / 2 - windowRect.size.width / 2;
@@ -118,7 +116,7 @@
   // displayRect is presented system(Xlib) coordiante system.
   // Convert newOrigin into OpenStep coordinate system (non-flipped).
   newOrigin.y = screenSize.height - (newOrigin.y + windowRect.size.height);
-  NSLog(@"New origin    :              (%4.0f, %4.0f)", newOrigin.x, newOrigin.y);
+  NSDebugLLog(@"Screen", @"New origin    :              (%4.0f, %4.0f)", newOrigin.x, newOrigin.y);
 
   [self setFrameOrigin:newOrigin];
 }

--- a/Applications/Login/LoginWindow.m
+++ b/Applications/Login/LoginWindow.m
@@ -74,7 +74,7 @@
 */
 - (void)center
 {
-  OSEScreen *screen;
+  OSEScreen *screen = [[NSApp delegate] systemScreen];
   OSEDisplay *display = nil;
   NSSize screenSize;
   NSRect displayRect;
@@ -84,7 +84,7 @@
   NSLog(@"center");
 
   // Get NEXTSPACE display rect
-  screen = [OSEScreen new];
+  // screen = [OSEScreen new];
   if (screen != nil) {
     if ([[screen activeDisplays] count] > 0) {
       display = [screen mainDisplay];
@@ -102,7 +102,7 @@
 
     NSLog(@"Screen size   : %4.0f x %4.0f", screenSize.width, screenSize.height);
   }
-  [screen release];
+  // [screen release];
 
   NSLog(@"Display frame : %4.0f x %4.0f  (%4.0f, %4.0f)", displayRect.size.width,
         displayRect.size.height, displayRect.origin.x, displayRect.origin.y);

--- a/Applications/Login/LoginWindow.m
+++ b/Applications/Login/LoginWindow.m
@@ -84,7 +84,7 @@
   NSLog(@"center");
 
   // Get NEXTSPACE display rect
-  screen = [OSEScreen sharedScreen];
+  screen = [OSEScreen new];
   if (screen != nil) {
     if ([[screen activeDisplays] count] > 0) {
       display = [screen mainDisplay];
@@ -102,6 +102,7 @@
 
     NSLog(@"Screen size   : %4.0f x %4.0f", screenSize.width, screenSize.height);
   }
+  [screen release];
 
   NSLog(@"Display frame : %4.0f x %4.0f  (%4.0f, %4.0f)", displayRect.size.width,
         displayRect.size.height, displayRect.origin.x, displayRect.origin.y);

--- a/Applications/Login/LoginWindow.m
+++ b/Applications/Login/LoginWindow.m
@@ -85,6 +85,7 @@
 
   // Get NEXTSPACE display rect
   if (screen != nil) {
+    [screen randrUpdateScreenResources];
     if ([[screen activeDisplays] count] > 0) {
       display = [screen mainDisplay];
       if (!display) {

--- a/Applications/Login/LoginWindow.m
+++ b/Applications/Login/LoginWindow.m
@@ -38,9 +38,9 @@
 // It was neccesary to override this method to get the borderless
 // window since it is not available from InterfaceBuilder.
 - (id)initWithContentRect:(NSRect)contentRect
-		styleMask:(NSUInteger)styleMask
-		  backing:(NSBackingStoreType)bufferingType
-		    defer:(BOOL)flag
+                styleMask:(NSUInteger)styleMask
+                  backing:(NSBackingStoreType)bufferingType
+                    defer:(BOOL)flag
 {
   return [super initWithContentRect:contentRect
                           styleMask:NSBorderlessWindowMask
@@ -55,31 +55,31 @@
 
 - (BOOL)canBecomeMainWindow
 {
-  // If set to YES login window appears regrdless of 
+  // If set to YES login window appears regrdless of
   // "Visible at launch time" bit set
   return NO;
 }
 
-/* 
-   This method is a temporary solution. GNUstep doesn't count screen size and 
+/*
+   This method is a temporary solution. GNUstep doesn't count screen size and
    display laying out to each other on multi-display setups. For example, if 2
-   displays stacked side-by-side with top edges aligned by the Y axis 
-   (deafult layout) we need to add bottom side offset to point.y because GNUstep 
-   coordinate system starts at bottom left corner. If displays aligned by bottom 
-   edge - no offset have to be added. 
+   displays stacked side-by-side with top edges aligned by the Y axis
+   (deafult layout) we need to add bottom side offset to point.y because GNUstep
+   coordinate system starts at bottom left corner. If displays aligned by bottom
+   edge - no offset have to be added.
    The worst case is when displays are not aligned along some edge(s).
-   In this case XRandR screen dimensions increase while GNUstep is not aware of 
-   such changes. We need to adjust `point` to be correct in GNUstep coordinate 
+   In this case XRandR screen dimensions increase while GNUstep is not aware of
+   such changes. We need to adjust `point` to be correct in GNUstep coordinate
    system and screen dimensions.
 */
 - (void)center
 {
-  OSEScreen  *screen;
+  OSEScreen *screen;
   OSEDisplay *display = nil;
-  NSSize     screenSize;
-  NSRect     displayRect;
-  NSRect     windowRect = [self frame];
-  NSPoint    newOrigin;
+  NSSize screenSize;
+  NSRect displayRect;
+  NSRect windowRect = [self frame];
+  NSPoint newOrigin;
 
   NSLog(@"center");
 
@@ -92,30 +92,27 @@
         NSLog(@"No main display - using first active.");
         display = [[screen activeDisplays] objectAtIndex:0];
       }
-    }
-    else if ([[screen connectedDisplays] count] > 0) {
+    } else if ([[screen connectedDisplays] count] > 0) {
       NSLog(@"No active displays left - activating first connected.");
       display = [[screen connectedDisplays] objectAtIndex:0];
       [screen activateDisplay:display];
     }
     screenSize = [screen sizeInPixels];
     displayRect = [display frame];
-    
+
     NSLog(@"Screen size   : %4.0f x %4.0f", screenSize.width, screenSize.height);
   }
-  
-  NSLog(@"Display frame : %4.0f x %4.0f  (%4.0f, %4.0f)",
-        displayRect.size.width, displayRect.size.height,
-        displayRect.origin.x, displayRect.origin.y);
 
-  NSLog(@"Window frame  : %4.0f x %4.0f  (%4.0f, %4.0f)",
-        windowRect.size.width, windowRect.size.height, 
-        windowRect.origin.x, windowRect.origin.y);
+  NSLog(@"Display frame : %4.0f x %4.0f  (%4.0f, %4.0f)", displayRect.size.width,
+        displayRect.size.height, displayRect.origin.x, displayRect.origin.y);
+
+  NSLog(@"Window frame  : %4.0f x %4.0f  (%4.0f, %4.0f)", windowRect.size.width,
+        windowRect.size.height, windowRect.origin.x, windowRect.origin.y);
 
   // Calculate the new position of the window on display.
-  newOrigin.x = displayRect.size.width/2 - windowRect.size.width/2;
+  newOrigin.x = displayRect.size.width / 2 - windowRect.size.width / 2;
   newOrigin.x += displayRect.origin.x;
-  newOrigin.y = displayRect.size.height/2 - windowRect.size.height/2;
+  newOrigin.y = displayRect.size.height / 2 - windowRect.size.height / 2;
   newOrigin.y += displayRect.origin.y;
   // displayRect is presented system(Xlib) coordiante system.
   // Convert newOrigin into OpenStep coordinate system (non-flipped).
@@ -129,32 +126,31 @@
 
 - (NSPoint)windowScreenOrigin
 {
-  NSRect  allScreensFrame;
-  NSRect  frame = [self frame];
+  NSRect allScreensFrame;
+  NSRect frame = [self frame];
   NSPoint origin = frame.origin;
-  
+
   for (NSScreen *scr in [NSScreen screens]) {
     allScreensFrame = NSUnionRect(allScreensFrame, [scr frame]);
   }
-  
+
   origin.y = NSMaxY(allScreensFrame) - NSMaxY(frame);
 
-  NSLog(@"[screen origin] Y -> Xlib: %.0f Max: %.0f Screen: %.0f (Max: %.0f)",
-        origin.y, NSMaxY(frame),
-        allScreensFrame.origin.y, NSMaxY(allScreensFrame));
-  
+  NSLog(@"[screen origin] Y -> Xlib: %.0f Max: %.0f Screen: %.0f (Max: %.0f)", origin.y,
+        NSMaxY(frame), allScreensFrame.origin.y, NSMaxY(allScreensFrame));
+
   return origin;
 }
 
-- (void)shakePanel:(Window)panel onDisplay:(Display*)dpy
+- (void)shakePanel:(Window)panel onDisplay:(Display *)dpy
 {
   NSPoint origin = [self windowScreenOrigin];
-  int     x, initial_x, y;
-  int     i, j, num_steps, num_shakes;
+  int x, initial_x, y;
+  int i, j, num_steps, num_shakes;
 
   initial_x = x = (int)origin.x;
   y = (int)origin.y;
-    
+
   num_steps = 4;
   num_shakes = 14;
   for (i = 0; i < num_shakes; i++) {
@@ -164,7 +160,7 @@
       XSync(dpy, false);
       usleep(ANIMATION_DELAY);
     }
-    for (j = 0; j < num_steps*2; j++) {
+    for (j = 0; j < num_steps * 2; j++) {
       x -= 10;
       XMoveWindow(dpy, panel, x, y);
       XSync(dpy, false);
@@ -185,12 +181,12 @@
 
 - (void)shrinkPanel:(Window)panel onDisplay:(Display *)dpy
 {
-  NSRect  windowRect = [self frame];
+  NSRect windowRect = [self frame];
   NSPoint origin = [self windowScreenOrigin];
-  GC      gc;
-  Pixmap  pixmap;
-  XImage  *windowSnap;
-  int     x, y, width, height, initial_x, initial_width;
+  GC gc;
+  Pixmap pixmap;
+  XImage *windowSnap;
+  int x, y, width, height, initial_x, initial_width;
 
   initial_x = x = (int)origin.x;
   y = (int)origin.y;
@@ -199,17 +195,16 @@
 
   pixmap = XCreatePixmap(dpy, panel, width, height, 24);
   gc = XCreateGC(dpy, pixmap, 0, NULL);
-    
+
   windowSnap = XGetImage(dpy, panel, 0, 0, width, height, AllPlanes, XYPixmap);
   XPutImage(dpy, pixmap, gc, windowSnap, 0, 0, 0, 0, width, height);
-    
+
   while ((width - SHRINK_FACTOR) > 0) {
-    x += SHRINK_FACTOR/2;
+    x += SHRINK_FACTOR / 2;
     width -= SHRINK_FACTOR;
-    
+
     XMoveResizeWindow(dpy, panel, x, y, width, height);
-    XCopyArea(dpy, pixmap, pixmap, gc,
-              SHRINK_FACTOR/2, 0, width, height, 0, 0);
+    XCopyArea(dpy, pixmap, pixmap, gc, SHRINK_FACTOR / 2, 0, width, height, 0, 0);
     XSetWindowBackgroundPixmap(dpy, panel, pixmap);
     XSync(dpy, False);
     usleep(ANIMATION_DELAY);
@@ -219,7 +214,7 @@
   // panel before XMoveResizeWindow results will  made visible.
   XMoveResizeWindow(dpy, panel, initial_x, y, initial_width, height);
   XSync(dpy, False);
-  
+
   XFree(windowSnap);
   XFreeGC(dpy, gc);
   XFreePixmap(dpy, pixmap);

--- a/Applications/Login/LoginWindow.m
+++ b/Applications/Login/LoginWindow.m
@@ -84,7 +84,7 @@
   NSLog(@"center");
 
   // Get NEXTSPACE display rect
-  screen = [[OSEScreen new] autorelease];
+  screen = [OSEScreen sharedScreen];
   if (screen != nil) {
     if ([[screen activeDisplays] count] > 0) {
       display = [screen mainDisplay];

--- a/Applications/Login/Login_main.m
+++ b/Applications/Login/Login_main.m
@@ -137,7 +137,7 @@ int startWindowServer()
 
 void setupDisplays()
 {
-  OSEScreen *screen = [OSEScreen sharedScreen];
+  OSEScreen *screen = [OSEScreen new];
   OSEDisplay *mainDisplay = nil;
   OSEPower *systemPower = nil;
   NSArray *layout;
@@ -163,12 +163,12 @@ void setupDisplays()
   [screen applyDisplayLayout:layout];
   [screen setMainDisplay:mainDisplay];
 
-  // mainDisplay = [screen displayWithMouseCursor];
   xDisplay = XOpenDisplay(NULL);
   xRootWindow = RootWindow(xDisplay, DefaultScreen(xDisplay));
   XWarpPointer(xDisplay, None, xRootWindow, 0, 0, 0, 0, (int)mainDisplay.frame.origin.x + 50,
                (int)mainDisplay.frame.origin.y + 50);
   XCloseDisplay(xDisplay);
+  [screen release];
 }
 
 //-----------------------------------------------------------------------------
@@ -329,13 +329,13 @@ int main(int argc, const char **argv)
     plymouthQuit(YES);
 
     //--- StartupHook -----------------------------------------------------------
-    // StartupHook defined only system defaults (root user or app bundle)
-    startupHook = [loginDefaults objectForKey:@"StartupHook"];
-    if ([startupHook isEqualToString:@""] == NO) {
-      if (runCommand(startupHook, YES) != 0) {
-        NSLog(@"Warning: StartupHook run is not successful.");
-      }
-    }
+    // // StartupHook defined only system defaults (root user or app bundle)
+    // startupHook = [loginDefaults objectForKey:@"StartupHook"];
+    // if ([startupHook isEqualToString:@""] == NO) {
+    //   if (runCommand(startupHook, YES) != 0) {
+    //     NSLog(@"Warning: StartupHook run is not successful.");
+    //   }
+    // }
     //---------------------------------------------------------------------------
 
     //--- AppKit application ----------------------------------------------------
@@ -347,6 +347,8 @@ int main(int argc, const char **argv)
     [LoginApplication sharedApplication];
     NSApplicationMain(argc, argv);
     //---------------------------------------------------------------------------
+
+    NSLog(@"Application has quit RunLoop");
 
     // Stop Window Server
     if (xorgTask != nil) {
@@ -363,10 +365,10 @@ int main(int argc, const char **argv)
     plymouthStart(1);
 
     // Panel stopped it's execution - check exit code
-    exitCommand = commandForExitCode(panelExitCode);
-    if (exitCommand && [exitCommand isEqualToString:@""] == NO) {
-      runCommand(exitCommand, NO);
-    }
+    // exitCommand = commandForExitCode(panelExitCode);
+    // if (exitCommand && [exitCommand isEqualToString:@""] == NO) {
+    //   runCommand(exitCommand, NO);
+    // }
   } else {  // Xorg server start failed - cleanup
     NSLog(@"Unable to start Login Panel: no Window Server available.");
     plymouthQuit(YES);

--- a/Applications/Login/Login_main.m
+++ b/Applications/Login/Login_main.m
@@ -100,7 +100,7 @@ int startWindowServer()
     [xorgTask setArguments:serverArgs];
     [xorgTask setCurrentDirectoryPath:@"/"];
 
-    NSLog(@"================> Xorg is coming up <================");
+    NSLog(@"============> Xorg is coming up <==============");
     @try {
       [xorgTask launch];
     } @catch (NSException *e) {
@@ -128,7 +128,7 @@ int startWindowServer()
     XClearWindow(xDisplay, xRootWindow);
     XSync(xDisplay, false);
 
-    NSLog(@"================> Xorg is ready <================");
+    NSLog(@"==============> Xorg is ready <================");
     XCloseDisplay(xDisplay);
   }
 
@@ -329,20 +329,19 @@ int main(int argc, const char **argv)
     plymouthQuit(YES);
 
     //--- StartupHook -----------------------------------------------------------
-    // // StartupHook defined only system defaults (root user or app bundle)
-    // startupHook = [loginDefaults objectForKey:@"StartupHook"];
-    // if ([startupHook isEqualToString:@""] == NO) {
-    //   if (runCommand(startupHook, YES) != 0) {
-    //     NSLog(@"Warning: StartupHook run is not successful.");
-    //   }
-    // }
+    // StartupHook defined only system defaults (root user or app bundle)
+    startupHook = [loginDefaults objectForKey:@"StartupHook"];
+    if ([startupHook isEqualToString:@""] == NO) {
+      if (runCommand(startupHook, YES) != 0) {
+        NSLog(@"Warning: StartupHook run is not successful.");
+      }
+    }
     //---------------------------------------------------------------------------
 
     //--- AppKit application ----------------------------------------------------
     // Since there is no window manager running yet, we'll want to
     // do window decorations ourselves
     [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"GSX11HandlesWindowDecorations"];
-    // setenv("FREETYPE_PROPERTIES", "truetype:interpreter-version=35", 1);
     // Start our application without appicon
     [LoginApplication sharedApplication];
     NSApplicationMain(argc, argv);
@@ -362,13 +361,15 @@ int main(int argc, const char **argv)
     }
 
     // Show shutdown Plymouth splash screen
-    plymouthStart(1);
+    if (panelExitCode != QuitExitCode) {
+      plymouthStart(1);
+    }
 
     // Panel stopped it's execution - check exit code
-    // exitCommand = commandForExitCode(panelExitCode);
-    // if (exitCommand && [exitCommand isEqualToString:@""] == NO) {
-    //   runCommand(exitCommand, NO);
-    // }
+    exitCommand = commandForExitCode(panelExitCode);
+    if (exitCommand && [exitCommand isEqualToString:@""] == NO) {
+      runCommand(exitCommand, NO);
+    }
   } else {  // Xorg server start failed - cleanup
     NSLog(@"Unable to start Login Panel: no Window Server available.");
     plymouthQuit(YES);

--- a/Applications/Login/Login_main.m
+++ b/Applications/Login/Login_main.m
@@ -139,6 +139,7 @@ void setupDisplays()
 {
   OSEScreen *screen = [OSEScreen sharedScreen];
   OSEDisplay *mainDisplay = nil;
+  OSEPower *systemPower = nil;
   NSArray *layout;
   Display *xDisplay;
   Window xRootWindow;
@@ -150,10 +151,12 @@ void setupDisplays()
   displays = [screen activeDisplays];
   for (OSEDisplay *display in displays) {
     if (display.isBuiltin) {
-      if (![OSEPower isLidClosed] && [displays count] > 1) {
+      systemPower = [OSEPower new];
+      if (![systemPower isLidClosed] && [displays count] > 1) {
         [screen setMainDisplay:display];
         mainDisplay = display;
       }
+      [systemPower release];
     } else if (mainDisplay == nil) {
       mainDisplay = display;
     }

--- a/Applications/Login/Login_main.m
+++ b/Applications/Login/Login_main.m
@@ -151,12 +151,11 @@ void setupDisplays()
   displays = [screen activeDisplays];
   for (OSEDisplay *display in displays) {
     if (display.isBuiltin) {
-      systemPower = [OSEPower new];
+      systemPower = [OSEPower sharedPower];
       if (![systemPower isLidClosed] && [displays count] > 1) {
         [screen setMainDisplay:display];
         mainDisplay = display;
       }
-      [systemPower release];
     } else if (mainDisplay == nil) {
       mainDisplay = display;
     }

--- a/Applications/Login/Login_main.m
+++ b/Applications/Login/Login_main.m
@@ -137,9 +137,9 @@ int startWindowServer()
 
 void setupDisplays()
 {
+  NSLog(@"setupDisplays() - START");
   OSEScreen *screen = [OSEScreen new];
   OSEDisplay *mainDisplay = nil;
-  OSEPower *systemPower = nil;
   NSArray *layout;
   Display *xDisplay;
   Window xRootWindow;
@@ -151,8 +151,7 @@ void setupDisplays()
   displays = [screen activeDisplays];
   for (OSEDisplay *display in displays) {
     if (display.isBuiltin) {
-      systemPower = [OSEPower sharedPower];
-      if (![systemPower isLidClosed] && [displays count] > 1) {
+      if ([screen isLidClosed] == NO && [displays count] > 1) {
         [screen setMainDisplay:display];
         mainDisplay = display;
       }
@@ -169,6 +168,7 @@ void setupDisplays()
                (int)mainDisplay.frame.origin.y + 50);
   XCloseDisplay(xDisplay);
   [screen release];
+  NSLog(@"setupDisplays() - END");
 }
 
 //-----------------------------------------------------------------------------

--- a/Applications/Login/Preferences/Login.m
+++ b/Applications/Login/Preferences/Login.m
@@ -290,13 +290,12 @@
   [systemDefaults setObject:[NSNumber numberWithInteger:[sender state]]
                      forKey:@"RememberLastLoggedInUser"];
   [systemDefaults synchronize];
-  
-  [[NSDistributedNotificationCenter
-     notificationCenterForType:GSPublicNotificationCenterType]
-    postNotificationName:@"LoginDefaultsDidChangeNotification"
-                  object:@"Preferences"
-                userInfo:nil
-      deliverImmediately:YES];
+
+  [[NSDistributedNotificationCenter notificationCenterForType:GSPublicNotificationCenterType]
+      postNotificationName:@"LoginDefaultsDidChangeNotification"
+                    object:@"Preferences"
+                  userInfo:nil
+        deliverImmediately:YES];
 }
 - (IBAction)setDisplayHostName:(id)sender
 {
@@ -305,13 +304,12 @@
   [systemDefaults setObject:[NSNumber numberWithInteger:[sender state]]
                      forKey:@"DisplayHostName"];
   [systemDefaults synchronize];
-  
-  [[NSDistributedNotificationCenter
-     notificationCenterForType:GSPublicNotificationCenterType]
-    postNotificationName:@"LoginDefaultsDidChangeNotification"
-                  object:@"Preferences"
-                userInfo:nil
-      deliverImmediately:YES];
+
+  [[NSDistributedNotificationCenter notificationCenterForType:GSPublicNotificationCenterType]
+      postNotificationName:@"LoginDefaultsDidChangeNotification"
+                    object:@"Preferences"
+                  userInfo:nil
+        deliverImmediately:YES];
 }
 
 @end

--- a/Applications/Login/Resources/loginwindow.service
+++ b/Applications/Login/Resources/loginwindow.service
@@ -24,7 +24,7 @@ After=rc-local.service plymouth-start.service systemd-user-sessions.service
 OnFailure=plymouth-quit.service
 
 [Service]
-ExecStart=/usr/NextSpace/Apps/Login.app/Login
+ExecStart=/usr/NextSpace/Apps/Login.app/Login --GNU-Debug=dealloc
 ExecStartPost=-/bin/bash -c "TERM=linux /usr/bin/clear > /dev/tty1"
 KillMode=process
 KillSignal=SIGQUIT

--- a/Applications/Login/UserSession.h
+++ b/Applications/Login/UserSession.h
@@ -28,8 +28,8 @@
 
 @interface UserSession : NSObject
 {
-  Controller     *appController;
-  NSDictionary   *appDefaults;
+  Controller *appController;
+  NSDictionary *appDefaults;
   NSMutableArray *sessionScript;
 }
 
@@ -47,9 +47,7 @@
 
 // ---
 
-- (int)launchCommand:(NSArray *)command
-           logAppend:(BOOL)append
-                wait:(BOOL)isWait;
+- (int)launchCommand:(NSArray *)command logAppend:(BOOL)append wait:(BOOL)isWait;
 
 @end
 
@@ -57,4 +55,3 @@
 - (void)readSessionScript;
 - (void)launchSessionScript;
 @end
-

--- a/Applications/Login/gdb-Login.sh
+++ b/Applications/Login/gdb-Login.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+PROG_PATH="/usr/NextSpace/Apps/Login.app/Login"
+PROG_ARGS="--GNU-Debug=dealloc"
+
+PROG_NAME=`basename ${PROG_PATH}`
+
+WS_PID="`ps auxw|grep ${PROG_PATH}|grep -v grep|grep -v /bin/sh|awk -c '{print $2}'`"
+if [ "$WS_PID" == "" ];then
+    echo "Starting new '${PROG_NAME}' instance..."
+    gdb -q --args ${PROG_PATH} ${PROG_ARGS}
+else
+    echo "Found '${PROG_NAME}' PID: ${WS_PID}"
+    gdb ${PROG_PATH} -p ${WS_PID}
+fi

--- a/Applications/Preferences/AppController.m
+++ b/Applications/Preferences/AppController.m
@@ -89,11 +89,12 @@
     [mouse release];
 
     NSLog(@"Configuring Desktop background...");
-    OSEScreen *screen = [OSEScreen sharedScreen];
+    OSEScreen *screen = [OSEScreen new];
     CGFloat red, green, blue;
     if ([screen savedBackgroundColorRed:&red green:&green blue:&blue] == YES) {
       [screen setBackgroundColorRed:red green:green blue:blue];
     }
+    [screen release];
   } else {
     [self showPreferencesWindow];
   }

--- a/Applications/Preferences/Modules/Screen/DisplayBox.m
+++ b/Applications/Preferences/Modules/Screen/DisplayBox.m
@@ -74,27 +74,21 @@
 {
   CGFloat red, green, blue;
   NSColor *color;
-  
-  if (active)
-    {
-      [[OSEScreen sharedScreen] savedBackgroundColorRed:&red
-                                                 green:&green
-                                                  blue:&blue];
-      color = [NSColor colorWithDeviceRed:red
-                                    green:green
-                                     blue:blue
-                                    alpha:1.0];
-      [nameField setTextColor:[NSColor whiteColor]];
-    }
-  else
-    {
-      color = [NSColor darkGrayColor];
-      [nameField setTextColor:[NSColor lightGrayColor]];
-    }
+
+  if (active) {
+    OSEScreen *screen = [OSEScreen new];
+    [screen savedBackgroundColorRed:&red green:&green blue:&blue];
+    [screen release];
+    color = [NSColor colorWithDeviceRed:red green:green blue:blue alpha:1.0];
+    [nameField setTextColor:[NSColor whiteColor]];
+  } else {
+    color = [NSColor darkGrayColor];
+    [nameField setTextColor:[NSColor lightGrayColor]];
+  }
   ASSIGN(bgColor, color);
-  
+
   isActiveDisplay = active;
-  
+
   [[self superview] setNeedsDisplay:YES];
 }
 

--- a/Applications/Preferences/Modules/Screen/Screen.m
+++ b/Applications/Preferences/Modules/Screen/Screen.m
@@ -159,17 +159,15 @@
   [setMainBtn setEnabled:(![sender isMain]&&[sender isActive])];
   
   [setStateBtn setTitle:[sender isActive] ? @"Disable" : @"Enable"];
-  
-  if (([sender isActive] &&
-       [[systemScreen activeDisplays] count] > 1) ||
-      (![sender isActive] && ![OSEPower isLidClosed]))
-    {
-      [setStateBtn setEnabled:YES];
-    }
-  else
-    {
-      [setStateBtn setEnabled:NO];
-    }  
+
+  OSEPower *systemPower = [OSEPower new];
+  if (([sender isActive] && [[systemScreen activeDisplays] count] > 1) ||
+      (![sender isActive] && ![systemPower isLidClosed])) {
+    [setStateBtn setEnabled:YES];
+  } else {
+    [setStateBtn setEnabled:NO];
+  }
+  [systemPower release];
 }
 
 - (void)setMainDisplay:(id)sender

--- a/Applications/Workspace/Controller+NSWorkspace.m
+++ b/Applications/Workspace/Controller+NSWorkspace.m
@@ -39,13 +39,13 @@
 #import <Foundation/Foundation.h>
 #import <GNUstepGUI/GSDisplayServer.h>
 
+#import <SystemKit/OSEDefaults.h>
+#import <SystemKit/OSEFileManager.h>
 #import <SystemKit/OSEUDisksAdaptor.h>
 #import <SystemKit/OSEUDisksDrive.h>
 #import <SystemKit/OSEUDisksVolume.h>
 
 #import <DesktopKit/NXTAlert.h>
-#import <SystemKit/OSEDefaults.h>
-#import <SystemKit/OSEFileManager.h>
 
 #import "Viewers/FileViewer.h"
 #import "WMNotificationCenter.h"
@@ -477,7 +477,7 @@ static NSLock *raceLock = nil;
   *writableFlag = volume.isWritable;
   *unmountableFlag = !volume.isSystem;
 
-  switch (volume.type) {
+  switch (volume.filesystemType) {
     case NXTFSTypeEXT:
       *fileSystemType = @"EXT";
       break;

--- a/Applications/Workspace/Controller.m
+++ b/Applications/Workspace/Controller.m
@@ -712,19 +712,19 @@ static NSString *WMComputerShouldGoDownNotification = @"WMComputerShouldGoDownNo
 
   // OSEMediaManager
   // For future use
-  [nc addObserver:self selector:@selector(diskDidAdd:) name:OSEDiskDisappeared object:mediaAdaptor];
+  [nc addObserver:self selector:@selector(diskDidAdd:) name:OSEMediaDriveDidRemoveNotification object:mediaAdaptor];
   [nc addObserver:self
          selector:@selector(diskDidEject:)
-             name:OSEDiskDisappeared
+             name:OSEMediaDriveDidRemoveNotification
            object:mediaAdaptor];
   // Operations
   [nc addObserver:self
          selector:@selector(mediaOperationDidStart:)
-             name:OSEMediaOperationDidStart
+             name:OSEMediaOperationDidStartNotification
            object:mediaAdaptor];
   [nc addObserver:self
          selector:@selector(mediaOperationDidEnd:)
-             name:OSEMediaOperationDidEnd
+             name:OSEMediaOperationDidEndNotification
            object:mediaAdaptor];
 
   [mediaAdaptor checkForRemovableMedia];

--- a/Applications/Workspace/Controller.m
+++ b/Applications/Workspace/Controller.m
@@ -686,7 +686,7 @@ static NSString *WMComputerShouldGoDownNotification = @"WMComputerShouldGoDownNo
 
   // Init Workspace's tools
   mediaOperations = [[NSMutableDictionary alloc] init];
-  // [self mediaManager];
+  [self mediaManager];
   fileSystemMonitor = nil;
   console = nil;
   procPanel = nil;

--- a/Applications/Workspace/Controller.m
+++ b/Applications/Workspace/Controller.m
@@ -1429,7 +1429,7 @@ static NSString *WMComputerShouldGoDownNotification = @"WMComputerShouldGoDownNo
 - (void)lidDidChange:(NSNotification *)aNotif
 {
   OSEDisplay *builtinDisplay = nil;
-  OSEScreen *screen = [OSEScreen sharedScreen];
+  OSEScreen *screen = [OSEScreen new];
 
   for (OSEDisplay *d in [screen connectedDisplays]) {
     if ([d isBuiltin]) {
@@ -1447,7 +1447,7 @@ static NSString *WMComputerShouldGoDownNotification = @"WMComputerShouldGoDownNo
       [screen deactivateDisplay:builtinDisplay];
     }
   }
-  // [screen release];
+  [screen release];
 }
 
 //============================================================================

--- a/Applications/Workspace/Controller.m
+++ b/Applications/Workspace/Controller.m
@@ -383,6 +383,14 @@ static NSString *WMComputerShouldGoDownNotification = @"WMComputerShouldGoDownNo
 
 - (void)_finishTerminateProcess
 {
+  // Hide Dock
+  wDockHideIcons(wDefaultScreen()->dock);
+  if (recycler) {
+    [[recycler appIcon] close];
+    [recycler release];
+  }
+  [workspaceBadge release];
+
   // Remove monitored paths and associated data (NSWorkspace)
   for (NSString *dirPath in _appDirs) {
     [fileSystemMonitor removePath:dirPath];
@@ -405,6 +413,12 @@ static NSString *WMComputerShouldGoDownNotification = @"WMComputerShouldGoDownNo
     [fileSystemMonitor terminate];
   }
 
+  // Media and media manager
+  // NSDebugLLog(@"Controller", @"OSEMediaManager RC:%lu", [mediaManager retainCount]);
+  [mediaAdaptor ejectAllRemovables];
+  [mediaManager release];  //  mediaAdaptor released also
+  [mediaOperations release];
+
   // We don't need to handle events on quit.
   [[NSNotificationCenter defaultCenter] removeObserver:self];
   // Not need to remove observers explicitely for NSWorkspaceCenter.
@@ -415,20 +429,6 @@ static NSString *WMComputerShouldGoDownNotification = @"WMComputerShouldGoDownNo
 
   // Quit Window Manager - stop runloop and make cleanup
   // wShutdown(WMExitMode);
-
-  // Hide Dock
-  wDockHideIcons(wDefaultScreen()->dock);
-  if (recycler) {
-    [[recycler appIcon] close];
-    [recycler release];
-  }
-  [workspaceBadge release];
-
-  // Media and media manager
-  // NSDebugLLog(@"Controller", @"OSEMediaManager RC:%lu", [mediaManager retainCount]);
-  [mediaAdaptor ejectAllRemovables];
-  [mediaManager release];  //  mediaAdaptor released also
-  [mediaOperations release];
 
   // NXTSystem objects declared in Workspace+WM.h
   // [systemPower stopEventsMonitor];
@@ -1389,8 +1389,9 @@ static NSString *WMComputerShouldGoDownNotification = @"WMComputerShouldGoDownNo
     NXTRunAlertPanel([info objectForKey:@"Title"], [info objectForKey:@"Message"], nil, nil, nil);
   } else {
     Mounter *bgop = [[Mounter alloc] initWithInfo:info];
+    NSString *operationKey = [NSString stringWithFormat:@"%@-%@", info[@"Operation"], info[@"ID"]];
 
-    [mediaOperations setObject:bgop forKey:[bgop source]];
+    [mediaOperations setObject:bgop forKey:operationKey];
     [bgop release];
 
     NSDebugLLog(@"Controller", @"[Contoller media-start] <%@> %@ [%@]", [info objectForKey:@"Title"],
@@ -1402,19 +1403,23 @@ static NSString *WMComputerShouldGoDownNotification = @"WMComputerShouldGoDownNo
 {
   NSDictionary *info = [notif userInfo];
   NSString *source = [info objectForKey:@"UNIXDevice"];
-  Mounter *bgop = [mediaOperations objectForKey:source];
+  NSString *operation = info[@"Operation"];
+  NSString *operationKey = [NSString stringWithFormat:@"%@-%@", operation, info[@"ID"]];
+  Mounter *bgop = [mediaOperations objectForKey:operationKey];
 
-  if ([[info objectForKey:@"Success"] isEqualToString:@"false"] && bgop) {
-    [bgop destroyOperation:info];
-  } else if (bgop) {
-    if (_isQuitting) {
+  NSLog(@"[Controller] media operation completed successfuly. INFO: %@", info);
+  if (bgop) {
+    if ([[info objectForKey:@"Success"] isEqualToString:@"false"]) {
       [bgop destroyOperation:info];
     } else {
-      [bgop finishOperation:info];
+      if (_isQuitting) {
+        [bgop destroyOperation:info];
+      } else {
+        [bgop finishOperation:info];
+      }
     }
-    [mediaOperations removeObjectForKey:source];
-  } else  // probably disk ejected without unmounting
-  {
+    [mediaOperations removeObjectForKey:operationKey];
+  } else {
     [NSApp activateIgnoringOtherApps:YES];
     NXTRunAlertPanel([info objectForKey:@"Title"], [info objectForKey:@"Message"], nil, nil, nil);
   }

--- a/Applications/Workspace/Controller.m
+++ b/Applications/Workspace/Controller.m
@@ -431,8 +431,8 @@ static NSString *WMComputerShouldGoDownNotification = @"WMComputerShouldGoDownNo
   [mediaOperations release];
 
   // NXTSystem objects declared in Workspace+WM.h
-  [systemPower stopEventsMonitor];
-  [systemPower release];
+  // [systemPower stopEventsMonitor];
+  // [systemPower release];
 
   // System Beep
   if (bellSound) {
@@ -656,8 +656,8 @@ static NSString *WMComputerShouldGoDownNotification = @"WMComputerShouldGoDownNo
   // NSUpdateDynamicServices();
 
   // Detect lid close/open events
-  systemPower = [OSEPower new];
-  [systemPower startEventsMonitor];
+  // systemPower = [OSEPower sharedPower];
+  // [systemPower startEventsMonitor];
   NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
   [nc addObserver:self
          selector:@selector(lidDidChange:)
@@ -1429,7 +1429,7 @@ static NSString *WMComputerShouldGoDownNotification = @"WMComputerShouldGoDownNo
 - (void)lidDidChange:(NSNotification *)aNotif
 {
   OSEDisplay *builtinDisplay = nil;
-  OSEScreen *screen = [OSEScreen new];
+  OSEScreen *screen = [OSEScreen sharedScreen];
 
   for (OSEDisplay *d in [screen connectedDisplays]) {
     if ([d isBuiltin]) {
@@ -1447,7 +1447,7 @@ static NSString *WMComputerShouldGoDownNotification = @"WMComputerShouldGoDownNo
       [screen deactivateDisplay:builtinDisplay];
     }
   }
-  [screen release];
+  // [screen release];
 }
 
 //============================================================================

--- a/Applications/Workspace/Controller.m
+++ b/Applications/Workspace/Controller.m
@@ -712,7 +712,10 @@ static NSString *WMComputerShouldGoDownNotification = @"WMComputerShouldGoDownNo
 
   // OSEMediaManager
   // For future use
-  [nc addObserver:self selector:@selector(diskDidAdd:) name:OSEMediaDriveDidRemoveNotification object:mediaAdaptor];
+  [nc addObserver:self
+         selector:@selector(diskDidAdd:)
+             name:OSEMediaDriveDidRemoveNotification
+           object:mediaAdaptor];
   [nc addObserver:self
          selector:@selector(diskDidEject:)
              name:OSEMediaDriveDidRemoveNotification

--- a/Applications/Workspace/GNUmakefile.preamble
+++ b/Applications/Workspace/GNUmakefile.preamble
@@ -4,7 +4,7 @@
 #
 
 # Additional flags to pass to the preprocessor
-ADDITIONAL_CPPFLAGS += -DWITH_UPOWER -DREVISION=\"$(REVISION)\" -DLINUX -DWITH_UDISKS
+ADDITIONAL_CPPFLAGS += -DWITH_UPOWER -DREVISION=\"$(REVISION)\" -DLINUX
 ADDITIONAL_CPPFLAGS += -DAPP_ICON=\"$($(APP_NAME)_APPLICATION_ICON)\"
 
 # Additional flags to pass to Objective C compiler
@@ -14,10 +14,10 @@ ADDITIONAL_OBJCFLAGS += -Wall -Wno-unused-variable -Wno-typedef-redefinition
 #ADDITIONAL_CFLAGS +=
 
 # Additional flags to pass to the linker
-ADDITIONAL_LDFLAGS += `pkg-config --libs dbus-1 udisks2 upower-glib` -ldispatch -ldl -lbsd -fuse-ld=gold
+ADDITIONAL_LDFLAGS += `pkg-config --libs dbus-1` -ldispatch -ldl -lbsd
 
 # Additional include directories the compiler should search
-ADDITIONAL_INCLUDE_DIRS += -I./ `pkg-config --cflags dbus-1 udisks2 upower-glib`
+ADDITIONAL_INCLUDE_DIRS += -I./ `pkg-config --cflags dbus-1`
 
 # Additional library directories the linker should search
 ADDITIONAL_LIB_DIRS += 

--- a/Applications/Workspace/Operations/Mounter.m
+++ b/Applications/Workspace/Operations/Mounter.m
@@ -83,6 +83,7 @@
 - (void)destroyOperation:(id)object
 {
   NSDictionary *info = nil;
+  BOOL showAlert = NO;
 
   if (object && [object isKindOfClass:[NSTimer class]]) {
     info = [object userInfo];
@@ -94,13 +95,11 @@
   [[NSNotificationCenter defaultCenter] postNotificationName:WMOperationWillDestroyNotification
                                                       object:self];
 
-  if (info)
-    if (([[info objectForKey:@"Operation"] isEqualToString:@"Eject"] ||
-         [[info objectForKey:@"Success"] isEqualToString:@"false"]) &&
-        ![[info objectForKey:@"Message"] isEqualToString:@""]) {
-      [NSApp activateIgnoringOtherApps:YES];
-      NXTRunAlertPanel([info objectForKey:@"Title"], [info objectForKey:@"Message"], nil, nil, nil);
-    }
+  if (info && [[info objectForKey:@"Message"] isEqualToString:@""] == NO &&
+      ([[info objectForKey:@"Success"] isEqualToString:@"false"] != NO)) {
+    [NSApp activateIgnoringOtherApps:YES];
+    NXTRunAlertPanel([info objectForKey:@"Title"], [info objectForKey:@"Message"], nil, nil, nil);
+  }
 }
 
 - (void)finishOperation:(NSDictionary *)userInfo

--- a/Applications/Workspace/Viewers/FileViewer.m
+++ b/Applications/Workspace/Viewers/FileViewer.m
@@ -438,6 +438,8 @@
 {
   NSDebugLLog(@"Memory", @"FileViewer %@: dealloc", rootPath);
 
+  [[NSDistributedNotificationCenter notificationCenterForType:NSLocalNotificationCenterType]
+      removeObserver:self];
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 
   // [viewer release];

--- a/Applications/Workspace/Viewers/FileViewer.m
+++ b/Applications/Workspace/Viewers/FileViewer.m
@@ -1465,6 +1465,10 @@
   PathIcon *icon;
   NSString *iconPath;
 
+  if (mountPoint == nil) {
+    return;
+  }
+
   NSDebugLLog(@"FileViewer", @"Volume '%@' did mount at path: %@",
               [[notif userInfo] objectForKey:@"UNIXDevice"], mountPoint);
 
@@ -1494,6 +1498,10 @@
   PathIcon *icon;
   NSString *mountPoint = [[notif userInfo] objectForKey:@"MountPoint"];
   NSString *iconPath;
+
+  if (mountPoint == nil) {
+    return;
+  }
 
   NSDebugLLog(@"FileViewer", @"Volume '%@' mounted at '%@' did unmount",
               [[notif userInfo] objectForKey:@"UNIXDevice"], mountPoint);

--- a/Applications/Workspace/Viewers/FileViewer.m
+++ b/Applications/Workspace/Viewers/FileViewer.m
@@ -245,11 +245,11 @@
     // For updating views (Shelf, PathView, Viewer)
     [nc addObserver:self
            selector:@selector(volumeDidMount:)
-               name:NXVolumeMounted
+               name:OSEMediaVolumeDidMountNotification
              object:mediaManager];
     [nc addObserver:self
            selector:@selector(volumeDidUnmount:)
-               name:NXVolumeUnmounted
+               name:OSEMediaVolumeDidUnmountNotification
              object:mediaManager];
   }
 

--- a/Applications/Workspace/Viewers/ShelfView.m
+++ b/Applications/Workspace/Viewers/ShelfView.m
@@ -172,7 +172,7 @@
 
   for (NSString *mountPath in mountPoints) {
     info = [NSDictionary dictionaryWithObject:mountPath forKey:@"MountPoint"];
-    notif = [NSNotification notificationWithName:NXVolumeMounted object:mediaManager userInfo:info];
+    notif = [NSNotification notificationWithName:OSEMediaVolumeDidMountNotification object:mediaManager userInfo:info];
     [_owner volumeDidMount:notif];
   }
 }

--- a/Applications/Workspace/Workspace+WM.m
+++ b/Applications/Workspace/Workspace+WM.m
@@ -248,7 +248,7 @@ void WSUpdateScreenInfo(WScreen *scr)
   XUnlockDisplay(dpy);
 
   NSDebugLLog(@"Screen", @"Sending OSEScreenDidChangeNotification...");
-  // Send notification to active OSEScreen applications.
+  // Send notification to active OSEScreen applications of current user.
   [[NSDistributedNotificationCenter defaultCenter]
       postNotificationName:OSEScreenDidChangeNotification
                     object:nil];

--- a/Applications/Workspace/Workspace_main.m
+++ b/Applications/Workspace/Workspace_main.m
@@ -139,19 +139,22 @@ int main(int argc, const char **argv)
 
   fprintf(stderr, "=== Starting Workspace ===\n");
   workspace_q = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
+  dispatch_sync(workspace_q, ^{
+    @autoreleasepool {
+      // Restore display layout
+      OSEScreen *screen = [OSEScreen sharedScreen];
+      [screen applySavedDisplayLayout];
+      [screen release];
+    }
+  });
   {
-    
     // DISPATCH_QUEUE_CONCURRENT is mandatory for CFRunLoop run.
-    dispatch_queue_t window_manager_q = dispatch_queue_create("ns.workspace.wm", DISPATCH_QUEUE_CONCURRENT);
+    dispatch_queue_t window_manager_q = dispatch_queue_create("ns.workspace.wm",
+                                                              DISPATCH_QUEUE_CONCURRENT);
 
     //--- Initialize Window Manager
     fprintf(stderr, "=== Initializing Window Manager ===\n");
     dispatch_sync(window_manager_q, ^{
-      @autoreleasepool {
-        // Restore display layout
-        [[[OSEScreen new] autorelease] applySavedDisplayLayout];
-      }
-
       wInitialize(argc, (char **)argv);
       wStartUp(True);
 

--- a/Applications/Workspace/Workspace_main.m
+++ b/Applications/Workspace/Workspace_main.m
@@ -142,7 +142,7 @@ int main(int argc, const char **argv)
   dispatch_sync(workspace_q, ^{
     @autoreleasepool {
       // Restore display layout
-      OSEScreen *screen = [OSEScreen sharedScreen];
+      OSEScreen *screen = [OSEScreen new];
       [screen applySavedDisplayLayout];
       [screen release];
     }

--- a/Applications/Workspace/gdb-Workspace.sh
+++ b/Applications/Workspace/gdb-Workspace.sh
@@ -3,8 +3,6 @@
 
 export CFNETWORK_LIBRARY_PATH="/usr/NextSpace/lib/libCFNetwork.so"
 
-gnustep-services start
-export DISPLAY=:0.0
 PROG_NAME="Workspace"
 PROG_PATH="/usr/NextSpace/Apps/Workspace.app/Workspace"
 PROG_ARGS="--GNU-Debug=DBus --GNU-Debug=dealloc"
@@ -12,10 +10,12 @@ PROG_ARGS="--GNU-Debug=DBus --GNU-Debug=dealloc"
 WS_PID="`ps auxw|grep ${PROG_NAME}|grep -v grep|grep -v /bin/sh|awk -c '{print $2}'`"
 if [ "$WS_PID" == "" ];then
     echo "Starting new '${PROG_NAME}' instance..."
+    export DISPLAY=:0.0
+    gnustep-services start
     gdb -q --args ${PROG_PATH} ${PROG_ARGS}
+    gnustep-services stop
 else
     echo "Found '${PROG_NAME}' PID: ${WS_PID}"
     gdb ${PROG_PATH} ${WS_PID}
 fi
 
-gnustep-services stop

--- a/Applications/Workspace/gdb-Workspace.sh
+++ b/Applications/Workspace/gdb-Workspace.sh
@@ -1,2 +1,21 @@
 #!/bin/sh
-gdb /usr/NextSpace/Apps/Workspace.app/Workspace `ps auxw|grep Workspace|grep -v grep|awk -c '{print $2}'`
+# /usr/libexec/Xorg :0 -noreset -background none -seat seat0 -nolisten tcp -keeptty vt1
+
+export CFNETWORK_LIBRARY_PATH="/usr/NextSpace/lib/libCFNetwork.so"
+
+gnustep-services start
+export DISPLAY=:0.0
+PROG_NAME="Workspace"
+PROG_PATH="/usr/NextSpace/Apps/Workspace.app/Workspace"
+PROG_ARGS="--GNU-Debug=DBus --GNU-Debug=dealloc"
+
+WS_PID="`ps auxw|grep ${PROG_NAME}|grep -v grep|grep -v /bin/sh|awk -c '{print $2}'`"
+if [ "$WS_PID" == "" ];then
+    echo "Starting new '${PROG_NAME}' instance..."
+    gdb -q --args ${PROG_PATH} ${PROG_ARGS}
+else
+    echo "Found '${PROG_NAME}' PID: ${WS_PID}"
+    gdb ${PROG_PATH} ${WS_PID}
+fi
+
+gnustep-services stop

--- a/Applications/nextspace-applications.spec
+++ b/Applications/nextspace-applications.spec
@@ -119,7 +119,7 @@ export CMAKE=%{CMAKE}
 %post
 if [ $1 -eq 1 ]; then
     # post-installation
-    systemctl enable /usr/NextSpace/Apps/Login.app/Resources/loginwindow.service
+    systemctl enable /usr/NextSpace/lib/systemd/loginwindow.service
     systemctl set-default graphical.target
     ldconfig
 elif [ $1 -eq 2 ]; then

--- a/Frameworks/DesktopKit/NXTAlert.h
+++ b/Frameworks/DesktopKit/NXTAlert.h
@@ -32,10 +32,12 @@
 // Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111 USA.
 //
 
-#include <AppKit/AppKit.h>
+#import <AppKit/AppKit.h>
+#import <SystemKit/OSEScreen.h>
 
 @interface NXTAlert : NSObject
 {
+  OSEScreen *systemScreen;
   NSPanel *panel;
 
   NSTextField *titleField;

--- a/Frameworks/DesktopKit/NXTAlert.m
+++ b/Frameworks/DesktopKit/NXTAlert.m
@@ -226,14 +226,13 @@
   selectedAttrs = @{NSBackgroundColorAttributeName:[NSColor controlLightHighlightColor]};
   [messageView setSelectedTextAttributes:selectedAttrs];
 
-  systemScreen = [OSEScreen new];
+  systemScreen = [OSEScreen sharedScreen];
 }
 
 - (void)dealloc
 {
   NSDebugLLog(@"Memory",@"NXTAlert: -dealloc");
   [buttons release];
-  [systemScreen release];
   [super dealloc];
 }
 

--- a/Frameworks/DesktopKit/NXTAlert.m
+++ b/Frameworks/DesktopKit/NXTAlert.m
@@ -317,7 +317,7 @@
 
 - (void)sizeToFitScreen
 {
-  OSEScreen *screen = [[OSEScreen new] autorelease];
+  OSEScreen *screen = [OSEScreen new];
   [self sizeToFitScreenSize:[screen sizeInPixels]];
 }
 

--- a/Frameworks/DesktopKit/NXTAlert.m
+++ b/Frameworks/DesktopKit/NXTAlert.m
@@ -24,7 +24,6 @@
 #import <AppKit/AppKitExceptions.h>
 #import <GNUstepGUI/GSDisplayServer.h>
 
-#import <SystemKit/OSEScreen.h>
 #import <SystemKit/OSEDisplay.h>
 #import <SystemKit/OSEMouse.h>
 #import "NXTAlert.h"
@@ -226,12 +225,15 @@
   
   selectedAttrs = @{NSBackgroundColorAttributeName:[NSColor controlLightHighlightColor]};
   [messageView setSelectedTextAttributes:selectedAttrs];
+
+  systemScreen = [OSEScreen new];
 }
 
 - (void)dealloc
 {
   NSDebugLLog(@"Memory",@"NXTAlert: -dealloc");
   [buttons release];
+  [systemScreen release];
   [super dealloc];
 }
 
@@ -317,8 +319,7 @@
 
 - (void)sizeToFitScreen
 {
-  OSEScreen *screen = [OSEScreen new];
-  [self sizeToFitScreenSize:[screen sizeInPixels]];
+  [self sizeToFitScreenSize:[systemScreen sizeInPixels]];
 }
 
 - (void)sizeToFitScreenSize:(NSSize)screenSize
@@ -353,9 +354,8 @@
   // Screen size possibly was changed after application start.
   // GNUstep information about screen size is obsolete. Adopt origin.y to
   // GNUstep screen coordinates.
-  OSEScreen  *screen = [[OSEScreen new] autorelease];
   OSEMouse   *mouse = [[OSEMouse new] autorelease];
-  OSEDisplay *display = [screen displayAtPoint:[mouse locationOnScreen]];
+  OSEDisplay *display = [systemScreen displayAtPoint:[mouse locationOnScreen]];
 
   if (display) {
     panelFrame.origin.x = display.frame.origin.x;

--- a/Frameworks/SystemKit/GNUmakefile
+++ b/Frameworks/SystemKit/GNUmakefile
@@ -36,6 +36,10 @@ $(FRAMEWORK_NAME)_HEADER_FILES = \
 	OSEScreen.h \
 	OSEDisplay.h \
 	\
+	OSEBusConnection.h \
+	OSEBusMessage.h \
+	OSEBusService.h \
+	\
 	OSEDeviceManager.h \
 	OSEMediaManager.h \
 	OSEUDisksAdaptor.h \

--- a/Frameworks/SystemKit/GNUmakefile.preamble
+++ b/Frameworks/SystemKit/GNUmakefile.preamble
@@ -16,7 +16,7 @@ ifeq ($(findstring freebsd, $(GNUSTEP_TARGET_OS)), freebsd)
 endif
 
 ifeq ($(findstring gnu, $(GNUSTEP_TARGET_OS)), gnu)
-  ADDITIONAL_OBJCFLAGS += -DLINUX 
+  ADDITIONAL_OBJCFLAGS += -DLINUX -DCF_BUS_CONNECTION
 #  -DWITH_UDISKS 
 #  -DWITH_UPOWER
 endif
@@ -46,7 +46,7 @@ endif
 ifeq ($(findstring gnu, $(GNUSTEP_TARGET_OS)), gnu)
 #  ADDITIONAL_LDFLAGS += `pkg-config --libs udisks2 dbus-1 upower-glib`
   ADDITIONAL_LDFLAGS += `pkg-config --libs dbus-1`
-  ADDITIONAL_LDFLAGS += -ldispatch
+  ADDITIONAL_LDFLAGS += -ldispatch -lCoreFoundation
 endif
 
 ### Additional library directories the linker should search

--- a/Frameworks/SystemKit/GNUmakefile.preamble
+++ b/Frameworks/SystemKit/GNUmakefile.preamble
@@ -4,9 +4,9 @@
 #
 
 ### Additional flags to pass to the preprocessor
-ifeq ($(LIBACPI), yes)
-  ADDITIONAL_CPPFLAGS += -DLIBACPI
-endif
+#ifeq ($(LIBACPI), yes)
+#  ADDITIONAL_CPPFLAGS += -DLIBACPI
+#endif
 
 ### Additional flags to pass to Objective C compiler
 ADDITIONAL_OBJCFLAGS += -W -Wall -Wno-import -Wno-unused -Wno-unused-parameter -pipe
@@ -16,7 +16,8 @@ ifeq ($(findstring freebsd, $(GNUSTEP_TARGET_OS)), freebsd)
 endif
 
 ifeq ($(findstring gnu, $(GNUSTEP_TARGET_OS)), gnu)
-  ADDITIONAL_OBJCFLAGS += -DLINUX -DWITH_UDISKS 
+  ADDITIONAL_OBJCFLAGS += -DLINUX 
+#  -DWITH_UDISKS 
 #  -DWITH_UPOWER
 endif
 
@@ -32,8 +33,8 @@ endif
 
 ifeq ($(findstring gnu, $(GNUSTEP_TARGET_OS)), gnu)
 #  ADDITIONAL_INCLUDE_DIRS += `pkg-config --cflags udisks2 dbus-1 upower-glib`
-  ADDITIONAL_INCLUDE_DIRS += `pkg-config --cflags udisks2 dbus-1`
-  ADDITIONAL_INCLUDE_DIRS += -I/usr/include/gio-unix-2.0
+#  ADDITIONAL_INCLUDE_DIRS += -I/usr/include/gio-unix-2.0
+  ADDITIONAL_INCLUDE_DIRS += `pkg-config --cflags dbus-1`
 endif
 
 ### Additional flags to pass to the linker
@@ -44,7 +45,7 @@ endif
 
 ifeq ($(findstring gnu, $(GNUSTEP_TARGET_OS)), gnu)
 #  ADDITIONAL_LDFLAGS += `pkg-config --libs udisks2 dbus-1 upower-glib`
-  ADDITIONAL_LDFLAGS += `pkg-config --libs udisks2 dbus-1`
+  ADDITIONAL_LDFLAGS += `pkg-config --libs dbus-1`
   ADDITIONAL_LDFLAGS += -ldispatch
 endif
 

--- a/Frameworks/SystemKit/GNUmakefile.preamble
+++ b/Frameworks/SystemKit/GNUmakefile.preamble
@@ -16,7 +16,8 @@ ifeq ($(findstring freebsd, $(GNUSTEP_TARGET_OS)), freebsd)
 endif
 
 ifeq ($(findstring gnu, $(GNUSTEP_TARGET_OS)), gnu)
-  ADDITIONAL_OBJCFLAGS += -DLINUX -DCF_BUS_CONNECTION
+  ADDITIONAL_OBJCFLAGS += -DLINUX 
+#  -DCF_BUS_CONNECTION
 #  -DWITH_UDISKS 
 #  -DWITH_UPOWER
 endif

--- a/Frameworks/SystemKit/GNUmakefile.preamble
+++ b/Frameworks/SystemKit/GNUmakefile.preamble
@@ -16,7 +16,8 @@ ifeq ($(findstring freebsd, $(GNUSTEP_TARGET_OS)), freebsd)
 endif
 
 ifeq ($(findstring gnu, $(GNUSTEP_TARGET_OS)), gnu)
-  ADDITIONAL_OBJCFLAGS += -DLINUX -DWITH_UDISKS -DWITH_UPOWER
+  ADDITIONAL_OBJCFLAGS += -DLINUX -DWITH_UDISKS 
+#  -DWITH_UPOWER
 endif
 
 ### Additional flags to pass to C compiler
@@ -30,7 +31,8 @@ ifeq ($(findstring freebsd, $(GNUSTEP_TARGET_OS)), freebsd)
 endif
 
 ifeq ($(findstring gnu, $(GNUSTEP_TARGET_OS)), gnu)
-  ADDITIONAL_INCLUDE_DIRS += `pkg-config --cflags udisks2 dbus-1 upower-glib`
+#  ADDITIONAL_INCLUDE_DIRS += `pkg-config --cflags udisks2 dbus-1 upower-glib`
+  ADDITIONAL_INCLUDE_DIRS += `pkg-config --cflags udisks2 dbus-1`
   ADDITIONAL_INCLUDE_DIRS += -I/usr/include/gio-unix-2.0
 endif
 
@@ -41,7 +43,8 @@ ifeq ($(findstring freebsd, $(GNUSTEP_TARGET_OS)), freebsd)
 endif
 
 ifeq ($(findstring gnu, $(GNUSTEP_TARGET_OS)), gnu)
-  ADDITIONAL_LDFLAGS += `pkg-config --libs udisks2 dbus-1 upower-glib`
+#  ADDITIONAL_LDFLAGS += `pkg-config --libs udisks2 dbus-1 upower-glib`
+  ADDITIONAL_LDFLAGS += `pkg-config --libs udisks2 dbus-1`
   ADDITIONAL_LDFLAGS += -ldispatch
 endif
 

--- a/Frameworks/SystemKit/OSEBusConnection.h
+++ b/Frameworks/SystemKit/OSEBusConnection.h
@@ -12,7 +12,8 @@
 {
  @private
   int socketFileDescriptor;
-  NSMutableDictionary *signalFilters;
+  // NSMutableDictionary *signalFilters;
+  CFMutableDictionaryRef signalObservers;
 
 #ifdef CF_BUS_CONNECTION
   CFRunLoopRef run_loop;

--- a/Frameworks/SystemKit/OSEBusConnection.h
+++ b/Frameworks/SystemKit/OSEBusConnection.h
@@ -3,18 +3,34 @@
 #include <dbus/dbus.h>
 #include <dbus/dbus-protocol.h>
 
+#ifdef CF_BUS_CONNECTION
+#include <CoreFoundation/CoreFoundation.h>
+#include <CoreFoundation/CFFileDescriptor.h>
+#endif
+
 @interface OSEBusConnection : NSObject
 {
  @private
   int socketFileDescriptor;
-  NSFileHandle *socketFileHandle;
   NSMutableDictionary *signalFilters;
+
+#ifdef CF_BUS_CONNECTION
+  CFRunLoopRef run_loop;
+  CFFileDescriptorRef dbus_fd;
+  CFRunLoopSourceRef runloop_fd_source;
+#else
+  NSFileHandle *socketFileHandle;
+#endif
 }
 
 @property (readonly) DBusConnection *dbus_connection;
 @property (readonly) DBusError dbus_error;
 
 + (instancetype)defaultConnection;
+
+#ifdef CF_BUS_CONNECTION
+- (void)run;
+#endif
 
 - (void)addSignalObserver:(id)anObserver
                  selector:(SEL)aSelector

--- a/Frameworks/SystemKit/OSEBusConnection.h
+++ b/Frameworks/SystemKit/OSEBusConnection.h
@@ -37,10 +37,12 @@
                  selector:(SEL)aSelector
                    signal:(NSString *)signalName
                    object:(NSString *)objectPath
-                interface:(NSString *)aInterface
-             notification:(NSString *)notificationName;
+                interface:(NSString *)aInterface;
 
-- (void)removeSignalObserver:(id)anObserver name:(NSString *)notificationName;
+- (void)removeSignalObserver:(id)anObserver
+                      signal:(NSString *)signalName
+                      object:(NSString *)objectPath
+                   interface:(NSString *)aInterface;
 
 - (void)handleSignal:(NSString *)signalName
               object:(NSString *)objectPath

--- a/Frameworks/SystemKit/OSEBusConnection.h
+++ b/Frameworks/SystemKit/OSEBusConnection.h
@@ -12,8 +12,8 @@
 {
  @private
   int socketFileDescriptor;
-  // NSMutableDictionary *signalFilters;
   CFMutableDictionaryRef signalObservers;
+  BOOL isSignalFilterDidSet;
 
 #ifdef CF_BUS_CONNECTION
   CFRunLoopRef run_loop;

--- a/Frameworks/SystemKit/OSEBusConnection.h
+++ b/Frameworks/SystemKit/OSEBusConnection.h
@@ -1,0 +1,65 @@
+#import <Foundation/Foundation.h>
+
+#include <dbus/dbus.h>
+#include <dbus/dbus-protocol.h>
+
+@interface OSEBusConnection : NSObject
+{
+ @private
+  int socketFileDescriptor;
+  NSFileHandle *socketFileHandle;
+  NSMutableDictionary *signalFilters;
+}
+
+@property (readonly) DBusConnection *dbus_connection;
+@property (readonly) DBusError dbus_error;
+
++ (instancetype)defaultConnection;
+
+- (void)addSignalObserver:(id)anObserver
+                 selector:(SEL)aSelector
+                   signal:(NSString *)signalName
+                   object:(NSString *)objectPath
+                interface:(NSString *)aInterface
+             notification:(NSString *)notificationName;
+
+- (void)removeSignalObserver:(id)anObserver name:(NSString *)notificationName;
+
+- (void)handleSignal:(NSString *)signalName
+              object:(NSString *)objectPath
+           interface:(NSString *)aInterface
+             message:(NSArray *)result;
+
+@end
+
+//* org.freedesktop.DBus.Introspectable
+@protocol DBus_Introspectable
+
+- (NSString *)Introspect;
+
+@end
+
+//* org.freedesktop.DBus.ObjectManager
+@protocol DBus_ObjectManager
+
+- (NSArray *)GetManagedObjects;
+
+@end
+
+//* org.freedesktop.DBus.Peer
+@protocol DBus_Peer
+
+- (NSString *)GetMachineId;
+- (void)Ping;
+
+@end
+
+//* org.freedesktop.DBus.Properties
+@protocol DBus_Properties
+
+- (void)Set:(NSString *)interfaceName name:(NSString *)propertyName value:(id)propertyValue;
+- (id)Get:(NSString *)interfaceName name:(NSString *)propertyName;
+- (NSArray *)GetAll;
+
+@end
+

--- a/Frameworks/SystemKit/OSEBusConnection.m
+++ b/Frameworks/SystemKit/OSEBusConnection.m
@@ -1,0 +1,165 @@
+#import "OSEBusConnection.h"
+#import "OSEBusMessage.h"
+
+static OSEBusConnection *defaultConnection = nil;
+
+static DBusHandlerResult _dbus_signal_handler_func(DBusConnection *connection, DBusMessage *message,
+                                                   void *info)
+{
+  // printf("Signal arrived --> serial=%u path=%s; interface=%s; member=%s sender=%s\n",
+  //        dbus_message_get_serial(message), dbus_message_get_path(message),
+  //        dbus_message_get_interface(message), dbus_message_get_member(message),
+  //        dbus_message_get_sender(message));
+
+  if (dbus_message_is_signal(message, DBUS_INTERFACE_LOCAL, "Disconnected")) {
+    return DBUS_HANDLER_RESULT_HANDLED;
+  }
+
+  if (message != NULL) {
+    OSEBusMessage *msg = [OSEBusMessage new];
+    NSMutableArray *result = [msg decodeDBusMessage:message];
+
+    if (result != nil) {
+      // NSLog(@"Signal message --> %@", result);
+      [defaultConnection
+          handleSignal:[NSString stringWithCString:dbus_message_get_member(message)]
+                object:[NSString stringWithCString:dbus_message_get_path(message)]
+             interface:[NSString stringWithCString:dbus_message_get_interface(message)]
+               message:result];
+      [result release];
+    }
+    [msg release];
+  }
+
+  return DBUS_HANDLER_RESULT_HANDLED;
+}
+
+@implementation OSEBusConnection
+
++ (instancetype)defaultConnection
+{
+  if (defaultConnection == nil) {
+    [[self alloc] init];
+  }
+  return defaultConnection;
+}
+
+- (void)dealloc
+{
+  dbus_connection_unref(_dbus_connection);
+  [super dealloc];
+}
+
+- (instancetype)init
+{
+  if (defaultConnection != nil) {
+    return defaultConnection;
+  }
+
+  [super init];
+
+  dbus_error_init(&_dbus_error);
+  _dbus_connection = dbus_bus_get(DBUS_BUS_SYSTEM, &_dbus_error);
+  dbus_bus_set_unique_name(_dbus_connection, "org.nextspace.dbus_talk");
+  dbus_connection_get_socket(_dbus_connection, &socketFileDescriptor);
+
+  NSLog(@"OSEBusConnection: initialized with socket FD: %i", socketFileDescriptor);
+  socketFileHandle = [[NSFileHandle alloc] initWithFileDescriptor:socketFileDescriptor];
+
+  defaultConnection = self;
+  signalFilters = [NSMutableDictionary new];
+
+  // Setup signal handling
+  dbus_connection_read_write_dispatch(_dbus_connection, 10);
+
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(processSocketData:)
+                                               name:NSFileHandleDataAvailableNotification
+                                             object:socketFileHandle];
+  [socketFileHandle waitForDataInBackgroundAndNotify];
+
+  return self;
+}
+
+- (void)processSocketData:(NSNotification *)aNotif
+{
+  NSLog(@"-> Process connection data...");
+
+  dbus_connection_read_write(_dbus_connection, 1);
+  dbus_connection_read_write_dispatch(_dbus_connection, 1);
+  
+  [socketFileHandle waitForDataInBackgroundAndNotify];
+
+  NSLog(@"<- Process connection data, end.");
+}
+
+- (void)addSignalObserver:(id)anObserver
+                 selector:(SEL)aSelector
+                   signal:(NSString *)signalName
+                   object:(NSString *)objectPath
+                interface:(NSString *)aInterface
+             notification:(NSString *)notificationName
+{
+  NSString *rule;
+  NSMutableArray<NSDictionary *> *objectSignals;
+
+  rule = [NSString stringWithFormat:@"path='%@',interface='%@',member='%@',type='signal'",
+                                    objectPath, aInterface, signalName];
+  dbus_bus_add_match(_dbus_connection, [rule cString], &_dbus_error);
+  if (dbus_error_is_set(&_dbus_error)) {
+    NSLog(@"OSEBusConnection Error %s: %s", _dbus_error.name, _dbus_error.message);
+  }
+
+  if (!dbus_connection_add_filter(_dbus_connection, _dbus_signal_handler_func, notificationName,
+                                  NULL)) {
+    NSLog(@"OSEBusConnection Error: Couldn't add D-Bus filter to observe signal!");
+    return;
+  }
+
+  // Add registered filter
+  // objectPath = ({Interface = aInterface; Signal = signalName;, ...)
+  objectSignals = signalFilters[objectPath];
+  if (objectSignals == nil) {
+    objectSignals = [NSMutableArray array];
+  }
+  [objectSignals addObject:@{
+    @"Interface" : aInterface,
+    @"Signal" : signalName,
+    @"Notification" : notificationName
+  }];
+  [signalFilters setObject:objectSignals forKey:objectPath];
+
+  // Setup notification observer
+  [[NSNotificationCenter defaultCenter] addObserver:anObserver
+                                           selector:aSelector
+                                               name:notificationName
+                                             object:self];
+}
+
+- (void)removeSignalObserver:(id)anObserver name:(NSString *)notificationName
+{
+  // TODO: remove D-Bus filter
+  [[NSNotificationCenter defaultCenter] removeObserver:anObserver
+                                                  name:notificationName
+                                                object:self];
+}
+
+- (void)handleSignal:(NSString *)signalName
+              object:(NSString *)objectPath
+           interface:(NSString *)aInterface
+             message:(NSArray *)result
+{
+  NSArray<NSDictionary *> *objectSignals = signalFilters[objectPath];
+
+  for (NSDictionary *signal in objectSignals) {
+    if ([signal[@"Signal"] isEqualToString:signalName] &&
+        [signal[@"Interface"] isEqualToString:aInterface]) {
+      // NSLog(@"notification %@ was sent", signal[@"Notification"]);
+      [[NSNotificationCenter defaultCenter] postNotificationName:signal[@"Notification"]
+                                                          object:self
+                                                        userInfo:@{@"Message" : result}];
+    }
+  }
+}
+
+@end

--- a/Frameworks/SystemKit/OSEBusConnection.m
+++ b/Frameworks/SystemKit/OSEBusConnection.m
@@ -67,23 +67,21 @@ static DBusHandlerResult _dbus_signal_handler_func(DBusConnection *connection, D
 
 - (void)dealloc
 {
-  NSDebugLLog(@"DBus", @"OSEBusConnection: dealloc");
+  NSDebugLLog(@"DBus", @"OSEBusConnection: -dealloc (retain count: %lu)", [self retainCount]);
 #ifdef CF_BUS_CONNECTION
 #else
   [socketFileHandle release];
 #endif
   [signalFilters release];
   dbus_connection_unref(_dbus_connection);
+  defaultConnection = nil;
   [super dealloc];
 }
 
 - (oneway void)release
 {
+  NSDebugLLog(@"dealloc", @"OSEBusConnection: -release (retain count: %lu)", [self retainCount]);
   [super release];
-  NSDebugLLog(@"DBus", @"OSEBusConnection: retain count: %lu", [self retainCount]);
-  if ([self retainCount] == 1) {
-    [self dealloc];
-  }
 }
 
 - (instancetype)init

--- a/Frameworks/SystemKit/OSEBusConnection.m
+++ b/Frameworks/SystemKit/OSEBusConnection.m
@@ -254,6 +254,9 @@ static DBusHandlerResult _dbus_signal_handler_func(DBusConnection *connection, D
   CFDictionaryRef observer;
   id observerObject;
 
+  NSLog(@"Removing observer %@ for `%@` signal", [anObserver className],
+        [NSString stringWithFormat:@"%@-%@-%@", objectPath, aInterface, signalName]);
+
   observerKey =
       CFStringCreateWithFormat(kCFAllocatorDefault, 0, CFSTR("%s-%s-%s"), [objectPath cString],
                                [aInterface cString], [signalName cString]);
@@ -273,7 +276,7 @@ static DBusHandlerResult _dbus_signal_handler_func(DBusConnection *connection, D
 
   // If observers list is empty - remove D-Bus match and observers entry
   if (objectsList != NULL && CFArrayGetCount(objectsList) == 0) {
-    NSLog(@"Obsevers array is empty for %s",
+    NSLog(@"Obsevers array is empty for %s - removing D-Bus rule and observers array.",
           CFStringGetCStringPtr(observerKey, kCFStringEncodingUTF8));
     
     NSString *rule;
@@ -282,6 +285,8 @@ static DBusHandlerResult _dbus_signal_handler_func(DBusConnection *connection, D
                                       objectPath, aInterface, signalName];
     dbus_bus_remove_match(_dbus_connection, [rule cString], &_dbus_error);
   }
+  NSLog(@"Observer %@ for `%@` signal removed.", [anObserver className],
+        [NSString stringWithFormat:@"%@-%@-%@", objectPath, aInterface, signalName]);
 }
 
 - (void)handleSignal:(NSString *)signalName

--- a/Frameworks/SystemKit/OSEBusConnection.m
+++ b/Frameworks/SystemKit/OSEBusConnection.m
@@ -226,14 +226,21 @@ static DBusHandlerResult _dbus_signal_handler_func(DBusConnection *connection, D
              message:(NSArray *)result
 {
   NSArray<NSDictionary *> *objectSignals = signalFilters[objectPath];
+  NSDictionary *info;
 
+  info = @{
+    @"ObjectPath" : objectPath,
+    // @"Signal" : signalName,
+    // @"Interface" : aInterface,
+    @"Message" : result
+  };
   for (NSDictionary *signal in objectSignals) {
     if ([signal[@"Signal"] isEqualToString:signalName] &&
         [signal[@"Interface"] isEqualToString:aInterface]) {
-      NSDebugLLog(@"DBus", @"OSEBusConnection: notification %@ was sent", signal[@"Notification"]);
       [[NSNotificationCenter defaultCenter] postNotificationName:signal[@"Notification"]
                                                           object:self
-                                                        userInfo:@{@"Message" : result}];
+                                                        userInfo:info];
+      NSDebugLLog(@"DBus", @"OSEBusConnection: notification %@ was sent", signal[@"Notification"]);
     }
   }
 }

--- a/Frameworks/SystemKit/OSEBusConnection.m
+++ b/Frameworks/SystemKit/OSEBusConnection.m
@@ -25,10 +25,10 @@ static OSEBusConnection *defaultConnection = nil;
 static DBusHandlerResult _dbus_signal_handler_func(DBusConnection *connection, DBusMessage *message,
                                                    void *info)
 {
-  // printf("Signal arrived --> serial=%u path=%s; interface=%s; member=%s sender=%s\n",
-  //        dbus_message_get_serial(message), dbus_message_get_path(message),
-  //        dbus_message_get_interface(message), dbus_message_get_member(message),
-  //        dbus_message_get_sender(message));
+  printf("Signal arrived --> serial=%u path=%s; interface=%s; member=%s sender=%s\n",
+         dbus_message_get_serial(message), dbus_message_get_path(message),
+         dbus_message_get_interface(message), dbus_message_get_member(message),
+         dbus_message_get_sender(message));
 
   // if (dbus_message_is_signal(message, DBUS_INTERFACE_LOCAL, "Disconnected")) {
   //   return DBUS_HANDLER_RESULT_HANDLED;
@@ -60,14 +60,14 @@ static DBusHandlerResult _dbus_signal_handler_func(DBusConnection *connection, D
 + (instancetype)defaultConnection
 {
   if (defaultConnection == nil) {
-    [[self alloc] init];
+    defaultConnection = [[OSEBusConnection alloc] init];
   }
   return defaultConnection;
 }
 
 - (void)dealloc
 {
-  NSDebugLLog(@"DBus", @"OSEBusConnection: -dealloc (retain count: %lu)", [self retainCount]);
+  NSDebugLLog(@"dealloc", @"OSEBusConnection: -dealloc (retain count: %lu)", [self retainCount]);
 #ifdef CF_BUS_CONNECTION
 #else
   [socketFileHandle release];
@@ -180,6 +180,7 @@ static DBusHandlerResult _dbus_signal_handler_func(DBusConnection *connection, D
 
   rule = [NSString stringWithFormat:@"path='%@',interface='%@',member='%@',type='signal'",
                                     objectPath, aInterface, signalName];
+  NSDebugLLog(@"UDisks", @"OSEBusConnection: adding signal observer with rule: %@", rule);
   dbus_bus_add_match(_dbus_connection, [rule cString], &_dbus_error);
   if (dbus_error_is_set(&_dbus_error)) {
     NSLog(@"OSEBusConnection Error %s: %s", _dbus_error.name, _dbus_error.message);

--- a/Frameworks/SystemKit/OSEBusMessage.h
+++ b/Frameworks/SystemKit/OSEBusMessage.h
@@ -1,0 +1,46 @@
+#import <Foundation/Foundation.h>
+
+#include <dbus/dbus.h>
+
+@class OSEBusConnection;
+@class OSEBusService;
+
+@interface OSEBusMessage : NSObject
+{
+  DBusMessage *dbus_message;
+  DBusError dbus_error;
+  OSEBusService *busService;
+}
+
+@property (readonly) DBusMessageIter dbus_message_iterator;
+
+- (instancetype)initWithService:(OSEBusService *)service
+                      interface:(NSString *)interfacePath  // org.clightd.clightd.Backlight2
+                         method:(NSString *)methodName;    // Get
+
+- (instancetype)initWithService:(OSEBusService *)service
+                      interface:(NSString *)interfacePath
+                         method:(NSString *)methodName
+                      arguments:(NSArray *)args
+                      signature:(NSString *)signature;
+
+- (instancetype)initWithService:(NSString *)servicePath
+                         object:(NSString *)objectPath
+                      interface:(NSString *)interfacePath
+                         method:(NSString *)methodName
+                      arguments:(NSArray *)args
+                      signature:(NSString *)signature;
+
+- (instancetype)initWithService:(NSString *)servicePath    // org.clightd.clightd
+                         object:(NSString *)objectPath     // /org/clightd/clightd/Backlight2
+                      interface:(NSString *)interfacePath  // org.clightd.clightd.Backlight2
+                         method:(NSString *)methodName;    // Get
+
+- (void)setMethodArguments:(NSArray *)args withSignature:(NSString *)signature;
+
+- (id)send;
+- (id)sendWithConnection:(OSEBusConnection *)connection;
+
+- (id)decodeDBusMessage:(DBusMessage *)message;
+
+@end

--- a/Frameworks/SystemKit/OSEBusMessage.h
+++ b/Frameworks/SystemKit/OSEBusMessage.h
@@ -24,17 +24,17 @@
                       arguments:(NSArray *)args
                       signature:(NSString *)signature;
 
-- (instancetype)initWithService:(NSString *)servicePath
-                         object:(NSString *)objectPath
-                      interface:(NSString *)interfacePath
-                         method:(NSString *)methodName
-                      arguments:(NSArray *)args
-                      signature:(NSString *)signature;
+- (instancetype)initWithServiceName:(NSString *)servicePath
+                             object:(NSString *)objectPath
+                          interface:(NSString *)interfacePath
+                             method:(NSString *)methodName
+                          arguments:(NSArray *)args
+                          signature:(NSString *)signature;
 
-- (instancetype)initWithService:(NSString *)servicePath    // org.clightd.clightd
-                         object:(NSString *)objectPath     // /org/clightd/clightd/Backlight2
-                      interface:(NSString *)interfacePath  // org.clightd.clightd.Backlight2
-                         method:(NSString *)methodName;    // Get
+- (instancetype)initWithServiceName:(NSString *)servicePath    // org.clightd.clightd
+                             object:(NSString *)objectPath     // /org/clightd/clightd/Backlight2
+                          interface:(NSString *)interfacePath  // org.clightd.clightd.Backlight2
+                             method:(NSString *)methodName;    // Get
 
 - (void)setMethodArguments:(NSArray *)args withSignature:(NSString *)signature;
 

--- a/Frameworks/SystemKit/OSEBusMessage.h
+++ b/Frameworks/SystemKit/OSEBusMessage.h
@@ -40,6 +40,8 @@
 
 - (id)send;
 - (id)sendWithConnection:(OSEBusConnection *)connection;
+- (BOOL)sendAsync;
+- (BOOL)sendAsyncWithConnection:(OSEBusConnection *)connection;
 
 - (id)decodeDBusMessage:(DBusMessage *)message;
 

--- a/Frameworks/SystemKit/OSEBusMessage.m
+++ b/Frameworks/SystemKit/OSEBusMessage.m
@@ -1,0 +1,498 @@
+#import "OSEBusConnection.h"
+#import "OSEBusService.h"
+
+#import "OSEBusMessage.h"
+
+#pragma mark - Decoding from D-Bus
+
+// Is not recursive
+static id getBasicType(DBusMessageIter *iter)
+{
+  int type = dbus_message_iter_get_arg_type(iter);
+  id result = nil;
+
+  if (type == DBUS_TYPE_INVALID) {
+    return result;
+  }
+
+  switch (type) {
+    case DBUS_TYPE_STRING: {
+      char *val;
+      dbus_message_iter_get_basic(iter, &val);
+      result = [NSString stringWithCString:val];
+    } break;
+    case DBUS_TYPE_BYTE: {
+      unsigned char val;
+      dbus_message_iter_get_basic(iter, &val);
+      result = [NSString stringWithFormat:@"%c", val];
+    } break;
+    case DBUS_TYPE_SIGNATURE: {
+      char *val;
+      dbus_message_iter_get_basic(iter, &val);
+      result = [NSString stringWithCString:val];
+    } break;
+    case DBUS_TYPE_OBJECT_PATH: {
+      char *val;
+      dbus_message_iter_get_basic(iter, &val);
+      result = [NSString stringWithCString:val];
+    } break;
+    case DBUS_TYPE_INT16: {
+      dbus_int16_t val;
+      dbus_message_iter_get_basic(iter, &val);
+      result = [NSNumber numberWithInt:val];
+    } break;
+    case DBUS_TYPE_UINT16: {
+      dbus_uint16_t val;
+      dbus_message_iter_get_basic(iter, &val);
+      result = [NSNumber numberWithUnsignedInt:val];
+    } break;
+    case DBUS_TYPE_INT32: {
+      dbus_int32_t val;
+      dbus_message_iter_get_basic(iter, &val);
+      result = [NSNumber numberWithInt:val];
+    } break;
+    case DBUS_TYPE_UINT32: {
+      dbus_uint32_t val;
+      dbus_message_iter_get_basic(iter, &val);
+      result = [NSNumber numberWithUnsignedInt:val];
+    } break;
+    case DBUS_TYPE_INT64: {
+      dbus_int64_t val;
+      dbus_message_iter_get_basic(iter, &val);
+      result = [NSNumber numberWithUnsignedInt:val];
+    } break;
+    case DBUS_TYPE_UINT64: {
+      dbus_uint64_t val;
+      dbus_message_iter_get_basic(iter, &val);
+      result = [NSNumber numberWithUnsignedInt:val];
+    } break;
+    case DBUS_TYPE_DOUBLE: {
+      double val;
+      dbus_message_iter_get_basic(iter, &val);
+      result = [NSNumber numberWithDouble:val];
+    } break;
+    case DBUS_TYPE_BOOLEAN: {
+      dbus_bool_t val;
+      dbus_message_iter_get_basic(iter, &val);
+      // printf("boolean : %u\n", val);
+      result = [NSNumber numberWithUnsignedInt:val];
+    } break;
+  }
+
+  return result;
+}
+
+// Is recursive. `result` have to be set at the first call to this function.
+static id decodeDBusMessage(DBusMessageIter *iter, id result)
+{
+  do {
+    int type = dbus_message_iter_get_arg_type(iter);
+    id basicResult;
+    DBusMessageIter subiter;
+    id subiterResult;
+
+    if (type == DBUS_TYPE_INVALID) {
+      break;
+    }
+
+    /*
+     * Basic types
+     */
+    if ((basicResult = getBasicType(iter)) != nil) {
+      if (result != nil) {
+        [result addObject:basicResult];
+      } else {
+        result = basicResult;
+        break;
+      }
+      continue;
+    }
+
+    /*
+     * Container types
+     */
+    if (type == DBUS_TYPE_VARIANT) {
+      dbus_message_iter_recurse(iter, &subiter);
+      subiterResult = decodeDBusMessage(&subiter, nil);
+      if (result != nil) {
+        [result addObject:subiterResult];
+      } else {
+        result = subiterResult;
+      }
+      break;
+    } else if (type == DBUS_TYPE_ARRAY || type == DBUS_TYPE_STRUCT) {
+      BOOL isBytesArray = NO;
+      id object;
+
+      // printf("array\n");
+
+      dbus_message_iter_recurse(iter, &subiter);
+      if (dbus_message_iter_get_arg_type(&subiter) == DBUS_TYPE_BYTE) {
+        subiterResult = [NSMutableString string];
+        isBytesArray = YES;
+      } else {
+        subiterResult = [NSMutableArray array];
+      }
+      while (dbus_message_iter_get_arg_type(&subiter) != DBUS_TYPE_INVALID) {
+        object = decodeDBusMessage(&subiter, nil);
+        if (object) {
+          if (isBytesArray != NO) {
+            if ([object isEqualToString:@"\000"] == NO) {
+              [subiterResult appendString:object];
+            }
+          } else {
+            [subiterResult addObject:object];
+          }
+        }
+        dbus_message_iter_next(&subiter);
+      }
+
+      if (result != nil) {
+        [result addObject:subiterResult];
+      } else {
+        result = subiterResult;
+        break;
+      }
+    } else if (type == DBUS_TYPE_DICT_ENTRY) {
+      id key, object;
+
+      // printf("dict_entry\n");
+
+      dbus_message_iter_recurse(iter, &subiter);
+      key = getBasicType(&subiter);
+      dbus_message_iter_next(&subiter);
+      object = decodeDBusMessage(&subiter, nil);
+      result = @{key : object};
+
+      break;
+    } else {
+      NSLog(@"BusKit error: unknown D-Bus data type '%c'", type);
+    }
+  } while (dbus_message_iter_next(iter));
+
+  return result;
+}
+
+#pragma mark - Encoding to D-Bus wire format (marshalling)
+
+static dbus_bool_t append_arg(DBusMessageIter *iter, NSArray *arguments, const char *dbus_signature);
+static dbus_bool_t append_array(DBusMessageIter *master_iterator, NSArray *elements,
+                                const char *signature);
+static dbus_bool_t append_struct(DBusMessageIter *master_iterator, NSArray *elements,
+                                 const char *signature);
+
+static void handle_oom(dbus_bool_t success)
+{
+  if (!success) {
+    NSException *exception;
+    exception = [NSException exceptionWithName:@"BKMessage: OOM"
+                                        reason:@"Ran out of memory"
+                                      userInfo:nil];
+    [exception raise];
+  }
+}
+static dbus_bool_t append_array(DBusMessageIter *master_iterator, NSArray *elements,
+                                const char *signature)
+{
+  DBusMessageIter array_iterator;
+  dbus_bool_t ret = false;
+  char elements_type = signature[0];
+
+  // open container with sub-iterator
+  char dbus_signature[2];
+  dbus_signature[0] = elements_type;
+  dbus_signature[1] = '\0';
+  ret = dbus_message_iter_open_container(master_iterator, DBUS_TYPE_ARRAY, dbus_signature,
+                                         &array_iterator);
+  handle_oom(ret);
+
+  for (id value in elements) {
+    printf("append_array of element type: %c\n", elements_type);
+    ret = append_arg(&array_iterator, value, signature);
+  }
+
+  // close sub-iterator
+  ret = dbus_message_iter_close_container(master_iterator, &array_iterator);
+
+  return ret;
+}
+// signature must point to the first element type of structure
+static dbus_bool_t append_struct(DBusMessageIter *master_iterator, NSArray *elements,
+                                 const char *signature)
+{
+  DBusMessageIter struct_iterator;
+  dbus_bool_t ret = false;
+
+  ret = dbus_message_iter_open_container(master_iterator, DBUS_TYPE_STRUCT, NULL, &struct_iterator);
+  handle_oom(ret);
+
+  for (int i = 0; signature[0] != DBUS_STRUCT_END_CHAR; i++) {
+    printf("append_struct of element type: %c\n", signature[0]);
+    ret = append_arg(&struct_iterator, elements[i], signature);
+    signature++;
+  }
+  signature++;
+
+  // close sub-iterator
+  ret = dbus_message_iter_close_container(master_iterator, &struct_iterator);
+
+  return ret;
+}
+static dbus_bool_t append_arg(DBusMessageIter *iter, id argument, const char *dbus_signature)
+{
+  const char *value = NULL;
+  dbus_bool_t ret;
+
+  if ([argument isKindOfClass:[NSString class]]) {
+    value = [argument cString];
+  } else if ([argument isKindOfClass:[NSNumber class]]) {
+    value = [[argument stringValue] cString];
+  }
+
+  switch (dbus_signature[0]) {
+    case DBUS_TYPE_BYTE: {
+      unsigned char byte = strtoul(value, NULL, 0);
+      ret = dbus_message_iter_append_basic(iter, DBUS_TYPE_BYTE, &byte);
+    } break;
+    case DBUS_TYPE_DOUBLE: {
+      // printf("append_arg DOUBLE: %s\n", value);
+      double d = strtod(value, NULL);
+      ret = dbus_message_iter_append_basic(iter, DBUS_TYPE_DOUBLE, &d);
+    } break;
+    case DBUS_TYPE_INT16: {
+      dbus_int16_t int16 = strtol(value, NULL, 0);
+      ret = dbus_message_iter_append_basic(iter, DBUS_TYPE_INT16, &int16);
+    } break;
+    case DBUS_TYPE_UINT16: {
+      dbus_uint16_t uint16 = strtoul(value, NULL, 0);
+      ret = dbus_message_iter_append_basic(iter, DBUS_TYPE_UINT16, &uint16);
+    } break;
+    case DBUS_TYPE_INT32: {
+      dbus_int32_t int32 = strtol(value, NULL, 0);
+      ret = dbus_message_iter_append_basic(iter, DBUS_TYPE_INT32, &int32);
+    } break;
+    case DBUS_TYPE_UINT32: {
+      dbus_uint32_t uint32;
+      // printf("append_arg UINT32: %s\n", value);
+      uint32 = strtoul(value, NULL, 0);
+      ret = dbus_message_iter_append_basic(iter, DBUS_TYPE_UINT32, &uint32);
+    } break;
+    case DBUS_TYPE_INT64: {
+      dbus_int64_t int64 = strtoll(value, NULL, 0);
+      ret = dbus_message_iter_append_basic(iter, DBUS_TYPE_INT64, &int64);
+    } break;
+    case DBUS_TYPE_UINT64: {
+      dbus_uint64_t uint64 = strtoull(value, NULL, 0);
+      ret = dbus_message_iter_append_basic(iter, DBUS_TYPE_UINT64, &uint64);
+    } break;
+    case DBUS_TYPE_BOOLEAN: {
+      dbus_bool_t boolean;
+      if ([argument isKindOfClass:[NSNumber class]]) {
+        boolean = [argument boolValue] ? TRUE : FALSE;
+      }
+      ret = dbus_message_iter_append_basic(iter, DBUS_TYPE_BOOLEAN, &boolean);
+    } break;
+    case DBUS_TYPE_STRING: {
+      // printf("append_arg STRING: %s\n", value);
+      ret = dbus_message_iter_append_basic(iter, DBUS_TYPE_STRING, &value);
+    } break;
+    case DBUS_TYPE_OBJECT_PATH: {
+      ret = dbus_message_iter_append_basic(iter, DBUS_TYPE_OBJECT_PATH, &value);
+    } break;
+    case DBUS_TYPE_ARRAY: {
+      dbus_signature++;
+      // NSLog(@"DBUS_TYPE_ARRAY: %@", argument);
+      append_array(iter, argument, dbus_signature);
+      ret = true;
+    } break;
+    case DBUS_STRUCT_BEGIN_CHAR: {
+      dbus_signature++;
+      // NSLog(@"DBUS_TYPE_STRUCT: %@", argument);
+      append_struct(iter, argument, dbus_signature);
+      ret = true;
+    } break;
+    default:
+      fprintf(stderr, "OSEBusessage: Unsupported data type specified %c\n", dbus_signature[0]);
+      exit(1);
+  }
+  handle_oom(ret);
+  return ret;
+}
+
+// static void append_variant(DBusMessageIter *iter, int type, const char *value)
+// {
+//   // DBusMessageIter subiter;
+//   // char sig[2] = "\0\0";
+//   // char *subtype = strdup(value);
+//   // char *c = NULL;
+
+//   // handle_oom(subtype != NULL);
+
+//   // c = strchr(subtype, ':');
+//   // if (!c) {
+//   //   fprintf(stderr, "BKMesage: missing variant subtype specifier\n");
+//   //   exit(1);
+//   // }
+//   // *c = '\0';
+//   // sig[0] = (char)type_from_name(subtype, TRUE);
+
+//   // handle_oom(dbus_message_iter_open_container(iter, DBUS_TYPE_VARIANT, sig, &subiter));
+//   // append_arg(&subiter, sig[0], c + 1);
+//   // free(subtype);
+//   // handle_oom(dbus_message_iter_close_container(iter, &subiter));
+// }
+
+// static void append_dict(DBusMessageIter *iter, int keytype, int valtype, const char *value)
+// {
+//   const char *val;
+//   char *dupval = strdup(value);
+
+//   handle_oom(dupval != NULL);
+
+//   val = strtok(dupval, ",");
+//   while (val != NULL) {
+//     DBusMessageIter subiter;
+
+//     handle_oom(dbus_message_iter_open_container(iter, DBUS_TYPE_DICT_ENTRY, NULL, &subiter));
+//     append_arg(&subiter, keytype, val);
+//     val = strtok(NULL, ",");
+//     if (val == NULL) {
+//       fprintf(stderr, "BKMessage: Malformed dictionary\n");
+//       exit(1);
+//     }
+//     append_arg(&subiter, valtype, val);
+//     handle_oom(dbus_message_iter_close_container(iter, &subiter));
+//     val = strtok(NULL, ",");
+//   }
+
+//   free(dupval);
+// }
+
+@implementation OSEBusMessage
+
+- (void)dealloc
+{
+  if (dbus_message) {
+    dbus_message_unref(dbus_message);
+  }
+  [super dealloc];
+}
+
+- (instancetype)initWithService:(OSEBusService *)service
+                      interface:(NSString *)interfacePath
+                         method:(NSString *)methodName
+{
+  busService = service;
+  return [self initWithService:service.serviceName
+                        object:service.objectPath
+                     interface:interfacePath
+                        method:methodName];
+}
+
+- (instancetype)initWithService:(OSEBusService *)service
+                      interface:(NSString *)interfacePath
+                         method:(NSString *)methodName
+                      arguments:(NSArray *)args
+                      signature:(NSString *)signature
+{
+  busService = service;
+  return [self initWithService:service.serviceName
+                        object:service.objectPath
+                     interface:interfacePath
+                        method:methodName
+                     arguments:args
+                     signature:signature];
+}
+
+- (instancetype)initWithService:(NSString *)servicePath
+                         object:(NSString *)objectPath
+                      interface:(NSString *)interfacePath
+                         method:(NSString *)methodName
+                      arguments:(NSArray *)args
+                      signature:(NSString *)signature
+{
+  [self initWithService:servicePath object:objectPath interface:interfacePath method:methodName];
+  [self setMethodArguments:args withSignature:signature];
+
+  return self;
+}
+
+// designated
+- (instancetype)initWithService:(NSString *)servicePath
+                         object:(NSString *)objectPath
+                      interface:(NSString *)interfacePath
+                         method:(NSString *)methodName
+{
+  [super init];
+
+  dbus_message = dbus_message_new_method_call(NULL, [objectPath cString], [interfacePath cString],
+                                              [methodName cString]);
+  dbus_message_set_auto_start(dbus_message, TRUE);
+  dbus_message_set_destination(dbus_message, [servicePath cString]);
+
+  return self;
+}
+
+- (void)setMethodArguments:(NSArray *)args withSignature:(NSString *)signature
+{
+  if (args != nil) {
+    const char *dbus_signature = [signature cString];
+
+    // NSLog(@"Set method arguments: %@ with signature: %s", args, dbus_signature);
+
+    dbus_message_iter_init_append(dbus_message, &_dbus_message_iterator);
+
+    for (id argument in args) {
+      append_arg(&_dbus_message_iterator, argument, dbus_signature);
+      dbus_signature++;
+    }
+  }
+}
+
+- (id)send
+{
+  if (busService) {
+    return [self sendWithConnection:busService.connection];
+  }
+  NSLog(@"OSBusMessage: called `send` without OSEBusService set. Return `nil`.");
+  return nil;
+}
+
+- (id)sendWithConnection:(OSEBusConnection *)connection
+{
+  DBusMessage *reply;
+  NSMutableArray *result = nil;
+
+  dbus_error_init(&dbus_error);
+  reply = dbus_connection_send_with_reply_and_block(connection.dbus_connection, dbus_message, -1,
+                                                    &dbus_error);
+  if (dbus_error_is_set(&dbus_error)) {
+    NSLog(@"OSEBusMessage Error %s: %s\n", dbus_error.name, dbus_error.message);
+    return nil;
+  }
+  if (reply) {
+    result = [NSMutableArray new];
+
+    dbus_message_iter_init(reply, &_dbus_message_iterator);
+    decodeDBusMessage(&_dbus_message_iterator, result);
+    dbus_message_unref(reply);
+  }
+
+  if (result && [result count] == 1) {
+    return result[0];
+  }
+
+  return result;
+}
+
+- (id)decodeDBusMessage:(DBusMessage *)message
+{
+  NSMutableArray *result = [NSMutableArray new];
+
+  dbus_message_iter_init(message, &_dbus_message_iterator);
+  decodeDBusMessage(&_dbus_message_iterator, result);
+
+  return result;
+}
+
+@end

--- a/Frameworks/SystemKit/OSEBusMessage.m
+++ b/Frameworks/SystemKit/OSEBusMessage.m
@@ -49,22 +49,22 @@ static id getBasicType(DBusMessageIter *iter)
     case DBUS_TYPE_INT32: {
       dbus_int32_t val;
       dbus_message_iter_get_basic(iter, &val);
-      result = [NSNumber numberWithInt:val];
+      result = [NSNumber numberWithInteger:val];
     } break;
     case DBUS_TYPE_UINT32: {
       dbus_uint32_t val;
       dbus_message_iter_get_basic(iter, &val);
-      result = [NSNumber numberWithUnsignedInt:val];
+      result = [NSNumber numberWithUnsignedInteger:val];
     } break;
     case DBUS_TYPE_INT64: {
       dbus_int64_t val;
       dbus_message_iter_get_basic(iter, &val);
-      result = [NSNumber numberWithUnsignedInt:val];
+      result = [NSNumber numberWithUnsignedInteger:val];
     } break;
     case DBUS_TYPE_UINT64: {
       dbus_uint64_t val;
       dbus_message_iter_get_basic(iter, &val);
-      result = [NSNumber numberWithUnsignedInt:val];
+      result = [NSNumber numberWithUnsignedInteger:val];
     } break;
     case DBUS_TYPE_DOUBLE: {
       double val;

--- a/Frameworks/SystemKit/OSEBusService.h
+++ b/Frameworks/SystemKit/OSEBusService.h
@@ -1,10 +1,33 @@
+/* -*- mode: objc -*- */
+//
+// Project: NEXTSPACE - SystemKit framework
+//
+// Description: Represents connection to specific D-Bus service.
+//
+// Copyright (C) 2025- Sergii Stoian
+//
+// This application is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation; either
+// version 2 of the License, or (at your option) any later version.
+//
+// This application is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Library General Public License for more details.
+//
+// You should have received a copy of the GNU General Public
+// License along with this library; if not, write to the Free
+// Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111 USA.
+//
+
 #import <Foundation/Foundation.h>
 
 @class OSEBusConnection;
 
 @interface OSEBusService : NSObject
 
-@property (readonly, retain, nonnull) OSEBusConnection *connection;
+@property (readonly, assign, nonnull) OSEBusConnection *connection;
 @property (readwrite, retain, nonnull) NSString *objectPath;
 @property (readwrite, retain, nonnull) NSString *serviceName;
 

--- a/Frameworks/SystemKit/OSEBusService.h
+++ b/Frameworks/SystemKit/OSEBusService.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+@class OSEBusConnection;
+
+@interface OSEBusService : NSObject
+
+@property (readonly, nonnull) OSEBusConnection *connection;
+@property (readwrite, retain, nonnull) NSString *objectPath;
+@property (readwrite, retain, nonnull) NSString *serviceName;
+
+@end

--- a/Frameworks/SystemKit/OSEBusService.h
+++ b/Frameworks/SystemKit/OSEBusService.h
@@ -4,7 +4,7 @@
 
 @interface OSEBusService : NSObject
 
-@property (readonly, nonnull) OSEBusConnection *connection;
+@property (readonly, retain, nonnull) OSEBusConnection *connection;
 @property (readwrite, retain, nonnull) NSString *objectPath;
 @property (readwrite, retain, nonnull) NSString *serviceName;
 

--- a/Frameworks/SystemKit/OSEBusService.m
+++ b/Frameworks/SystemKit/OSEBusService.m
@@ -1,0 +1,26 @@
+#import "OSEBusConnection.h"
+#import "OSEBusService.h"
+
+@implementation OSEBusService
+
+- (void)dealloc
+{
+  if (_objectPath) {
+    [_objectPath release];
+  }
+  if (_serviceName) {
+    [_serviceName release];
+  }
+  [super dealloc];
+}
+
+- (instancetype)init
+{
+  [super init];
+
+  _connection = [OSEBusConnection defaultConnection];
+
+  return self;
+}
+
+@end

--- a/Frameworks/SystemKit/OSEBusService.m
+++ b/Frameworks/SystemKit/OSEBusService.m
@@ -5,12 +5,16 @@
 
 - (void)dealloc
 {
-  if (_objectPath) {
-    [_objectPath release];
-  }
-  if (_serviceName) {
-    [_serviceName release];
-  }
+  // NSLog(@"_objectPath retain count: %lu", [_objectPath retainCount]);
+  // if (_objectPath) {
+  //   NSLog(@"_objectPath release");
+  //   [_objectPath release];
+  // }
+  // if (_serviceName) {
+  //   [_serviceName release];
+  // }
+  NSDebugLLog(@"DBus", @"OSEBusService: connection retain count: %lu", [_connection retainCount]);
+
   [super dealloc];
 }
 

--- a/Frameworks/SystemKit/OSEBusService.m
+++ b/Frameworks/SystemKit/OSEBusService.m
@@ -5,11 +5,14 @@
 
 - (void)dealloc
 {
-  NSDebugLLog(@"DBus",
+  NSDebugLLog(@"dealloc",
               @"OSEBusService: -dealloc (retain count: %lu) (connection retain count: %lu)",
               [self retainCount], [_connection retainCount]);
   // OSEBusConnection will be released by AutoReleasePool
 
+  // if ([_connection retainCount] == 1) {
+  //   [_connection release];
+  // }
   [super dealloc];
 }
 

--- a/Frameworks/SystemKit/OSEBusService.m
+++ b/Frameworks/SystemKit/OSEBusService.m
@@ -37,6 +37,8 @@
               @"OSEBusService: -dealloc (retain count: %lu) (connection retain count: %lu)",
               [self retainCount], [self.connection retainCount]);
 
+  [_objectPath release];
+  [_serviceName release];
   [_connection release];
   [super dealloc];
 }

--- a/Frameworks/SystemKit/OSEBusService.m
+++ b/Frameworks/SystemKit/OSEBusService.m
@@ -1,18 +1,43 @@
+/* -*- mode: objc -*- */
+//
+// Project: NEXTSPACE - SystemKit framework
+//
+// Description: Represents connection to specific D-Bus service.
+//
+// Copyright (C) 2025- Sergii Stoian
+//
+// This application is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation; either
+// version 2 of the License, or (at your option) any later version.
+//
+// This application is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Library General Public License for more details.
+//
+// You should have received a copy of the GNU General Public
+// License along with this library; if not, write to the Free
+// Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111 USA.
+//
+
 #import "OSEBusConnection.h"
 #import "OSEBusService.h"
 
 @implementation OSEBusService
 
+/*
+   `connection` property has `assign` attribute so retain count should be always 1.
+   Because we're owning connection to a specific D-Bus service - initiate disconnection.
+   Concrete class talks to a D-Bus service and must be the only instance (signleton).
+*/
 - (void)dealloc
 {
   NSDebugLLog(@"dealloc",
               @"OSEBusService: -dealloc (retain count: %lu) (connection retain count: %lu)",
-              [self retainCount], [_connection retainCount]);
-  // OSEBusConnection will be released by AutoReleasePool
+              [self retainCount], [self.connection retainCount]);
 
-  // if ([_connection retainCount] == 1) {
-  //   [_connection release];
-  // }
+  [_connection release];
   [super dealloc];
 }
 

--- a/Frameworks/SystemKit/OSEBusService.m
+++ b/Frameworks/SystemKit/OSEBusService.m
@@ -5,15 +5,10 @@
 
 - (void)dealloc
 {
-  // NSLog(@"_objectPath retain count: %lu", [_objectPath retainCount]);
-  // if (_objectPath) {
-  //   NSLog(@"_objectPath release");
-  //   [_objectPath release];
-  // }
-  // if (_serviceName) {
-  //   [_serviceName release];
-  // }
-  NSDebugLLog(@"DBus", @"OSEBusService: connection retain count: %lu", [_connection retainCount]);
+  NSDebugLLog(@"DBus",
+              @"OSEBusService: -dealloc (retain count: %lu) (connection retain count: %lu)",
+              [self retainCount], [_connection retainCount]);
+  // OSEBusConnection will be released by AutoReleasePool
 
   [super dealloc];
 }

--- a/Frameworks/SystemKit/OSEFileSystemMonitor.m
+++ b/Frameworks/SystemKit/OSEFileSystemMonitor.m
@@ -244,11 +244,13 @@ NSString *OSEFileSystemChangedAtPath = @"OSEFileSystemChangedAtPath";
 // Otherwise NSRunLoop blocked until all events will be handled.
 - (void)handleEvent:(NSDictionary *)event
 {
-  NSDebugLLog(@"OSEFileSystemMonitor",
-              @"OSEFileSystemMonitor: FS events %@ occured at path %@",
-              [event objectForKey:@"Operations"],
-              [event objectForKey:@"ChangedPath"]);
-      
+  NSDebugLLog(@"OSEFileSystemMonitor", @"OSEFileSystemMonitor: FS events %@ occured at path %@",
+              [event objectForKey:@"Operations"], [event objectForKey:@"ChangedPath"]);
+
+  if (monitorThreadPaused != NO || monitorThreadStopped != NO || monitorThreadTerminated != NO) {
+    return;
+  }
+
   [[NSNotificationCenter defaultCenter] 
         postNotificationName:@"OSEFileSystemChangedAtPath"
                       object:self

--- a/Frameworks/SystemKit/OSEHALAdaptor.m
+++ b/Frameworks/SystemKit/OSEHALAdaptor.m
@@ -167,12 +167,12 @@ watch_toggled(DBusWatch *watch,
     {
       if ([self _deviceWithUDI:UDI hasCapability:@"volume"])
         {
-          // NXVolumeAppeared
+          // OSEMediaVolumeDidAddNotification
           if ((description = [self _volumeDescriptionForUDI:UDI]) == nil)
             {
               return;
             }
-          [notificationCenter postNotificationName:NXVolumeAppeared
+          [notificationCenter postNotificationName:OSEMediaVolumeDidAddNotification
                                             object:deviceManager
                                           userInfo:description];
           // mount appeared volume
@@ -183,9 +183,9 @@ watch_toggled(DBusWatch *watch,
     {
       if ([self _deviceWithUDI:UDI hasCapability:@"volume"])
         {
-          // NXVolumeDisappeared
+          // OSEMediaVolumeDidRemoveNotification
           description = [self _volumeDescriptionForUDI:UDI];
-          [notificationCenter postNotificationName:NXVolumeDisappeared
+          [notificationCenter postNotificationName:OSEMediaVolumeDidRemoveNotification
                                             object:deviceManager
                                           userInfo:description];
         }
@@ -204,13 +204,13 @@ watch_toggled(DBusWatch *watch,
            description = [self _volumeDescriptionForUDI:UDI];
            if ([propVal boolValue])
              {
-               [notificationCenter postNotificationName:NXVolumeMounted
+               [notificationCenter postNotificationName:OSEMediaVolumeDidMountNotification
                                                  object:deviceManager
                                                userInfo:description];
              }
            else
              {
-               [notificationCenter postNotificationName:NXVolumeUnmounted
+               [notificationCenter postNotificationName:OSEMediaVolumeDidUnmountNotification
                                                  object:deviceManager
                                                userInfo:description];
              }

--- a/Frameworks/SystemKit/OSEMediaManager.h
+++ b/Frameworks/SystemKit/OSEMediaManager.h
@@ -29,16 +29,16 @@
 #import <Foundation/Foundation.h>
 
 // Events
-extern NSString *OSEDiskAppeared;
-extern NSString *OSEDiskDisappeared;
-extern NSString *NXVolumeAppeared;
-extern NSString *NXVolumeDisappeared;
-extern NSString *NXVolumeMounted;
-extern NSString *NXVolumeUnmounted;
+extern NSString *OSEMediaDriveDidAddNotification;
+extern NSString *OSEMediaDriveDidRemoveNotification;
+extern NSString *OSEMediaVolumeDidAddNotification;
+extern NSString *OSEMediaVolumeDidRemoveNotification;
+extern NSString *OSEMediaVolumeDidMountNotification;
+extern NSString *OSEMediaVolumeDidUnmountNotification;
 
-extern NSString *OSEMediaOperationDidStart;
-extern NSString *OSEMediaOperationDidUpdate;
-extern NSString *OSEMediaOperationDidEnd;
+extern NSString *OSEMediaOperationDidStartNotification;
+extern NSString *OSEMediaOperationDidUpdateNotification;
+extern NSString *OSEMediaOperationDidEndNotification;
 
 // Filesystem types
 typedef enum {

--- a/Frameworks/SystemKit/OSEMediaManager.m
+++ b/Frameworks/SystemKit/OSEMediaManager.m
@@ -29,16 +29,16 @@
 #endif
 
 // Volume events
-NSString *OSEDiskAppeared = @"OSEDiskAppeared";
-NSString *OSEDiskDisappeared = @"OSEDiskDisappeared";
-NSString *NXVolumeAppeared = @"NXVolumeAppeared";
-NSString *NXVolumeDisappeared = @"NXVolumeDisappeared";
-NSString *NXVolumeMounted = @"NXVolumeMounted";
-NSString *NXVolumeUnmounted = @"NXVolumeUnmounted";
+NSString *OSEMediaDriveDidAddNotification = @"OSEMediaDriveDidAddNotification";
+NSString *OSEMediaDriveDidRemoveNotification = @"OSEMediaDriveDidRemoveNotification";
+NSString *OSEMediaVolumeDidAddNotification = @"OSEMediaVolumeDidAddNotification";
+NSString *OSEMediaVolumeDidRemoveNotification = @"OSEMediaVolumeDidRemoveNotification";
+NSString *OSEMediaVolumeDidMountNotification = @"OSEMediaVolumeDidMountNotification";
+NSString *OSEMediaVolumeDidUnmountNotification = @"OSEMediaVolumeDidUnmountNotification";
 // Operations
-NSString *OSEMediaOperationDidStart = @"OSEMediaOperationDidStart";
-NSString *OSEMediaOperationDidUpdate = @"OSEMediaOperationDidUpdate";
-NSString *OSEMediaOperationDidEnd = @"OSEMediaOperationDidEnd";
+NSString *OSEMediaOperationDidStartNotification = @"OSEMediaOperationDidStartNotification";
+NSString *OSEMediaOperationDidUpdateNotification = @"OSEMediaOperationDidUpdateNotification";
+NSString *OSEMediaOperationDidEndNotification = @"OSEMediaOperationDidEndNotification";
 
 //-----------------------------------------------------------------------
 static id<MediaManager> adaptor;

--- a/Frameworks/SystemKit/OSEMediaManager.m
+++ b/Frameworks/SystemKit/OSEMediaManager.m
@@ -23,8 +23,7 @@
 
 #ifdef WITH_HAL
 #import <SystemKit/NXHALAdaptor.h>
-#endif
-#ifdef WITH_UDISKS
+#else
 #import "OSEUDisksAdaptor.h"
 #endif
 
@@ -56,16 +55,13 @@ static id<MediaManager> adaptor;
 
 - (id)init
 {
-  if (!(self = [super init]))
-    {
-      return nil;
-    }
-  
+  if (!(self = [super init])) {
+    return nil;
+  }
+
 #ifdef WITH_HAL
   adaptor = [[NXHALAdaptor alloc] init];
-#endif
-
-#ifdef WITH_UDISKS
+#else
   adaptor = [[OSEUDisksAdaptor alloc] init];
 #endif
 

--- a/Frameworks/SystemKit/OSEMediaManager.m
+++ b/Frameworks/SystemKit/OSEMediaManager.m
@@ -53,6 +53,15 @@ static id<MediaManager> adaptor;
   return adaptor;
 }
 
+- (void)dealloc
+{
+  NSDebugLLog(@"dealloc", @"OSEMediaManager: -dealloc (retain count: %lu)", [self retainCount]);
+
+  [adaptor release];
+  
+  [super dealloc];
+}
+
 - (id)init
 {
   if (!(self = [super init])) {
@@ -71,15 +80,6 @@ static id<MediaManager> adaptor;
 - (id<MediaManager>)adaptor
 {
   return adaptor;
-}
-
-- (void)dealloc
-{
-  NSLog(@"OSEMediaManager: dealloc");
-
-  [adaptor release];
-  
-  [super dealloc];
 }
 
 @end

--- a/Frameworks/SystemKit/OSEPower.h
+++ b/Frameworks/SystemKit/OSEPower.h
@@ -38,6 +38,8 @@
 @property (readonly) BOOL isLidPresent;
 @property (readonly) BOOL isLidClosed;
 
++ (id)sharedPower;
+
 // Battery information
 @property (readonly) BOOL isUsingBattery;
 - (unsigned int)batteryLife;

--- a/Frameworks/SystemKit/OSEPower.h
+++ b/Frameworks/SystemKit/OSEPower.h
@@ -2,7 +2,7 @@
 //
 // Project: NEXTSPACE - SystemKit framework
 //
-// Copyright (C) 2014-2019 Sergii Stoian
+// Copyright (C) 2024-present Sergii Stoian
 //
 // This application is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public
@@ -38,8 +38,6 @@
 @property (readonly) BOOL isLidPresent;
 @property (readonly) BOOL isLidClosed;
 
-+ (BOOL)isLidClosed;
-
 // Battery information
 @property (readonly) BOOL isUsingBattery;
 - (unsigned int)batteryLife;
@@ -51,6 +49,9 @@
 
 @end
 
+//-------------------------------------------------------------------------------
+#pragma mark - Notifications
+//-------------------------------------------------------------------------------
 extern NSString *OSEPowerPropertiesDidChangeNotification;
 extern NSString *OSEPowerLidDidChangeNotification;
 extern NSString *OSEPowerDeviceDidAddNotification;

--- a/Frameworks/SystemKit/OSEPower.h
+++ b/Frameworks/SystemKit/OSEPower.h
@@ -25,35 +25,34 @@
  * changing of power profile of system (tuned) and actions:
  * shutdown, restart, hibernate and sleep.
  */
-#ifdef WITH_UPOWER
 
-#import <Foundation/NSObject.h>
+#import <Foundation/Foundation.h>
 
-#include <upower.h>
+#import <SystemKit/OSEBusService.h>
 
-@class NSString;
-
-@interface OSEPower : NSObject
+@interface OSEPower : OSEBusService
 {
-  UpClient *upower_client;
 }
-// Battery information
-+ (unsigned int)batteryLife;
-+ (unsigned char)batteryPercent;
-+ (BOOL)isUsingBattery;
 
 // LID information
-+ (BOOL)hasLid;
+@property (readonly) BOOL isLidPresent;
+@property (readonly) BOOL isLidClosed;
+
 + (BOOL)isLidClosed;
-- (BOOL)hasLid;
-- (BOOL)isLidClosed;
-  
+
+// Battery information
+@property (readonly) BOOL isUsingBattery;
+- (unsigned int)batteryLife;
+- (unsigned char)batteryPercent;
+
 // Monitor for D-Bus messages
 - (void)startEventsMonitor;
 - (void)stopEventsMonitor;
 
 @end
 
+extern NSString *OSEPowerPropertiesDidChangeNotification;
 extern NSString *OSEPowerLidDidChangeNotification;
+extern NSString *OSEPowerDeviceDidAddNotification;
+extern NSString *OSEPowerDeviceDidRemoveNotification;
 
-#endif //WITH_UPOWER

--- a/Frameworks/SystemKit/OSEPower.m
+++ b/Frameworks/SystemKit/OSEPower.m
@@ -31,10 +31,11 @@ NSString *OSEPowerLidDidChangeNotification = @"OSEPowerLidDidChangeNotification"
 NSString *OSEPowerDeviceDidAddNotification = @"OSEPowerDeviceDidAddNotification";
 NSString *OSEPowerDeviceDidRemoveNotification = @"OSEPowerDeviceDidRemoveNotification";
 
-
 //-------------------------------------------------------------------------------
 #pragma mark - OSEPower implementation
 //-------------------------------------------------------------------------------
+static OSEPower *systemPower = nil;
+
 @implementation OSEPower (Private)
 
 - (id)_propertyValueWithName:(NSString *)propertyName ofClass:(Class)resultClass 
@@ -66,8 +67,21 @@ NSString *OSEPowerDeviceDidRemoveNotification = @"OSEPowerDeviceDidRemoveNotific
 
 @implementation OSEPower
 
++ (id)sharedPower
+{
+  if (systemPower == nil) {
+    systemPower = [[OSEPower alloc] init];
+  }
+
+  return systemPower;
+}
+
 - (id)init
 {
+  if (systemPower != nil) {
+    return systemPower;
+  }
+
   [super init];
 
   self.objectPath = @"/org/freedesktop/UPower";
@@ -78,7 +92,8 @@ NSString *OSEPowerDeviceDidRemoveNotification = @"OSEPowerDeviceDidRemoveNotific
 
 - (void)dealloc
 {
-  NSDebugLLog(@"DBus", @"OSEPower: dealloc");
+  NSDebugLLog(@"DBus", @"OSEPower: -dealloc (retain count: %lu)", [self retainCount]);
+  systemPower = nil;
   [super dealloc];
 }
 

--- a/Frameworks/SystemKit/OSEPower.m
+++ b/Frameworks/SystemKit/OSEPower.m
@@ -19,151 +19,197 @@
 // Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111 USA.
 //
 
-#ifdef WITH_UPOWER
-
-#import <Foundation/NSArray.h>
-// #import <Foundation/NSBundle.h>
-#import <Foundation/NSString.h>
-#import <Foundation/NSTimer.h>
-#import <Foundation/NSNotification.h>
-
+#import "OSEBusConnection.h"
+#import "OSEBusMessage.h"
 #import "OSEPower.h"
 
+NSString *OSEPowerPropertiesDidChangeNotification = @"OSEPowerPropertiesDidChangeNotification";
 NSString *OSEPowerLidDidChangeNotification = @"OSEPowerLidDidChangeNotification";
+NSString *OSEPowerDeviceDidAddNotification = @"OSEPowerDeviceDidAddNotification";
+NSString *OSEPowerDeviceDidRemoveNotification = @"OSEPowerDeviceDidRemoveNotification";
 
-static NSTimer   *monitorTimer;
-static GMainLoop *glib_mainloop;
-static OSEPower   *power;
+@implementation OSEPower (Private)
+
+- (id)_propertyValueWithName:(NSString *)propertyName ofClass:(Class)resultClass 
+{
+  OSEBusMessage *message;
+  id result = nil;
+
+  message = [[OSEBusMessage alloc] initWithService:self
+                                         interface:@"org.freedesktop.DBus.Properties"
+                                            method:@"Get"
+                                         arguments:@[ @"org.freedesktop.UPower", propertyName ]
+                                         signature:@"ss"];
+  result = [message send];
+  [message release];
+
+  if (result != nil) {
+    if ([result isKindOfClass:resultClass]) {
+      return result;
+    } else {
+      [result release];
+      result = nil;
+    }
+  }
+
+  return result;
+}
+
+@end
 
 @implementation OSEPower
 
 - (id)init
 {
-  power = self = [super init];
-  
+  [super init];
+
+  self.objectPath = @"/org/freedesktop/UPower";
+  self.serviceName = @"org.freedesktop.UPower";
+
   return self;
 }
 
 - (void)dealloc
 {
-  if ([monitorTimer isValid])
-    {
-      [self stopEventsMonitor];
-    }
-
-  g_object_unref(upower_client);
-  
   [super dealloc];
 }
 
 //-------------------------------------------------------------------------------
 // Battery
 //-------------------------------------------------------------------------------
-+ (unsigned int)batteryLife
+// TODO
+- (unsigned int)batteryLife
+{
+  return 0;
+}
+// TODO
+- (unsigned char)batteryPercent
 {
   return 0;
 }
 
-+ (unsigned char)batteryPercent
+- (BOOL)isUsingBattery
 {
-  return 0;
-}
+  BOOL isOnBattery = NO;
+  NSNumber *result = [self _propertyValueWithName:@"OnBattery" ofClass:[NSNumber class]];
 
-+ (BOOL)isUsingBattery
-{
-  return NO;
+  if (result != nil) {
+    isOnBattery = [result boolValue];
+    [result release];
+  }
+
+  return isOnBattery;
 }
 
 //-------------------------------------------------------------------------------
 // Laptop lid
 //-------------------------------------------------------------------------------
-+ (BOOL)hasLid
-{
-  UpClient *up_client = up_client_new();
-  BOOL     yn = up_client_get_lid_is_present(up_client);
-
-  g_object_unref(up_client);
-    
-  return yn;
-}
-
 + (BOOL)isLidClosed
 {
-  UpClient *up_client = up_client_new();
-  BOOL     yn = up_client_get_lid_is_closed(up_client);
-
-  g_object_unref(up_client);
-    
-  return yn;
+  OSEPower *power = [OSEPower new];
+  BOOL isLidClosed = [power isLidClosed];
+  [power release];
+  return isLidClosed;
 }
 
-- (BOOL)hasLid
+- (BOOL)isLidPresent
 {
-  return up_client_get_lid_is_present(upower_client);
+  BOOL isLidPresent = NO;
+  NSNumber *result = [self _propertyValueWithName:@"LidIsPresent" ofClass:[NSNumber class]];
+
+  if (result != nil) {
+    isLidPresent = [result boolValue];
+    [result release];
+  }
+
+  return isLidPresent;
 }
 
 - (BOOL)isLidClosed
 {
-  return up_client_get_lid_is_closed(upower_client);
+  BOOL isLidClosed = NO;
+  NSNumber *result = [self _propertyValueWithName:@"LidIsClosed" ofClass:[NSNumber class]];
+
+  if (result != nil) {
+    isLidClosed = [result boolValue];
+    [result release];
+  }
+
+  return isLidClosed;
 }
 
 //-------------------------------------------------------------------------------
 // UPower D-Bus events
 //-------------------------------------------------------------------------------
+- (void)handleLidNotification:(NSNotification *)aNotif
+{
+  NSLog(@"UPower received notification with user info: %@", aNotif.userInfo);
 
-static void
-up_device_added_cb(UpClient *client, UpDevice *device, gpointer user_data)
-{
-  NSLog(@"OSEPower: device %s added", up_device_to_text(device));
-}
-static void
-up_device_removed_cb(UpClient *client, UpDevice *device, gpointer user_data)
-{
-  // NSLog(@"OSEPower: device %s removed", up_device_to_text(device));
-  NSLog(@"OSEPower: some device was removed");
-}
-static void
-up_lid_closed_cb(UpClient *client, gpointer user_data)
-{
-  NSLog(@"OSEPower: LidClosed property changed");
-  [[NSNotificationCenter defaultCenter]
-    postNotificationName:OSEPowerLidDidChangeNotification
-                  object:power];
+  NSArray *message = aNotif.userInfo[@"Message"];  // s a{sv} as
+  NSArray *properties = message[1];                // a{sv}
+  id propertyValue;
+
+  // NSLog(@"\t Properties has been changed for interface %@:", message[0]);
+  for (NSDictionary *property in properties) {
+    for (NSString *propertyName in [property allKeys]) {
+      // propertyValue = property[propertyName];
+      // NSLog(@"\t\t %@ = %@", propertyName, propertyValue);
+      if ([propertyName isEqualToString:@"LidIsClosed"]) {
+        [[NSNotificationCenter defaultCenter]
+            postNotificationName:OSEPowerLidDidChangeNotification
+                          object:self
+                        userInfo:property];
+      }
+    }
+  }
 }
 
-// Timer selector
-- (void)_glibRunLoopIterate
+- (void)deviceAdded:(NSNotification *)aNotif
 {
-  g_main_context_iteration(g_main_loop_get_context(glib_mainloop), FALSE);
+  NSLog(@"UPower received notification DeviceAdded: %@", aNotif.userInfo);
+
+  [[NSNotificationCenter defaultCenter] postNotificationName:OSEPowerDeviceDidAddNotification
+                                                      object:self
+                                                    userInfo:aNotif.userInfo];
+}
+
+- (void)deviceRemoved:(NSNotification *)aNotif
+{
+  NSLog(@"UPower received notification with object: %@", aNotif.userInfo);
+
+  [[NSNotificationCenter defaultCenter] postNotificationName:OSEPowerDeviceDidRemoveNotification
+                                                      object:self
+                                                    userInfo:aNotif.userInfo];
 }
 
 - (void)startEventsMonitor
 {
-  upower_client = up_client_new();
+  [self.connection addSignalObserver:self
+                            selector:@selector(handleLidNotification:)
+                              signal:@"PropertiesChanged"
+                              object:self.objectPath
+                           interface:@"org.freedesktop.DBus.Properties"
+                        notification:OSEPowerPropertiesDidChangeNotification];
 
-  // Set events monitoring callbacks
-  g_signal_connect(upower_client, "device-added",
-                   G_CALLBACK(up_device_added_cb), NULL);
-  g_signal_connect(upower_client, "device-removed",
-                   G_CALLBACK(up_device_removed_cb), NULL);
-  g_signal_connect(upower_client, "notify::lid-is-closed",
-                   G_CALLBACK(up_lid_closed_cb), NULL);
-
-  glib_mainloop = g_main_loop_new(NULL, TRUE);
-  
-  monitorTimer = [NSTimer
-                   scheduledTimerWithTimeInterval:1.0
-                                           target:self
-                                         selector:@selector(_glibRunLoopIterate)
-                                         userInfo:nil
-                                          repeats:YES];
+  [self.connection addSignalObserver:self
+                            selector:@selector(deviceAdded:)
+                              signal:@"DeviceAdded"
+                              object:self.objectPath
+                           interface:@"org.freedesktop.UPower"
+                        notification:OSEPowerDeviceDidAddNotification];
+  [self.connection addSignalObserver:self
+                            selector:@selector(deviceRemoved:)
+                              signal:@"DeviceRemoved"
+                              object:self.objectPath
+                           interface:@"org.freedesktop.UPower"
+                        notification:OSEPowerDeviceDidRemoveNotification];
 }
 
 - (void)stopEventsMonitor
 {
-  [monitorTimer invalidate];
+  [self.connection removeSignalObserver:self name:OSEPowerPropertiesDidChangeNotification];
+  [self.connection removeSignalObserver:self name:OSEPowerDeviceDidAddNotification];
+  [self.connection removeSignalObserver:self name:OSEPowerDeviceDidRemoveNotification];
 }
 
 @end
-
-#endif //WITH_UPOWER

--- a/Frameworks/SystemKit/OSEPower.m
+++ b/Frameworks/SystemKit/OSEPower.m
@@ -96,7 +96,6 @@ static OSEPower *systemPower = nil;
 {
   NSDebugLLog(@"dealloc", @"OSEPower: -dealloc (retain count: %lu) (connection retain count: %lu)",
               [self retainCount], [self.connection retainCount]);
-  // OSEBusConnection wil be released in parent class (OSEBusService)
   systemPower = nil;
   [super dealloc];
 }
@@ -162,7 +161,7 @@ static OSEPower *systemPower = nil;
 //-------------------------------------------------------------------------------
 - (void)handleLidNotification:(NSDictionary *)info
 {
-  NSLog(@"UPower received notification with user info: %@", info);
+  NSDebugLLog(@"UPower", @"UPower received notification with user info: %@", info);
 
   NSArray *message = info[@"Message"];  // s a{sv} as
   NSArray *properties = message[1];     // a{sv}
@@ -184,7 +183,7 @@ static OSEPower *systemPower = nil;
 
 - (void)deviceAdded:(NSNotification *)aNotif
 {
-  NSLog(@"UPower received notification DeviceAdded: %@", aNotif.userInfo);
+  NSDebugLLog(@"UPower", @"UPower received notification DeviceAdded: %@", aNotif.userInfo);
 
   [[NSNotificationCenter defaultCenter] postNotificationName:OSEPowerDeviceDidAddNotification
                                                       object:self
@@ -193,7 +192,7 @@ static OSEPower *systemPower = nil;
 
 - (void)deviceRemoved:(NSNotification *)aNotif
 {
-  NSLog(@"UPower received notification with object: %@", aNotif.userInfo);
+  NSDebugLLog(@"UPower", @"UPower received notification with object: %@", aNotif.userInfo);
 
   [[NSNotificationCenter defaultCenter] postNotificationName:OSEPowerDeviceDidRemoveNotification
                                                       object:self

--- a/Frameworks/SystemKit/OSEPower.m
+++ b/Frameworks/SystemKit/OSEPower.m
@@ -23,11 +23,18 @@
 #import "OSEBusMessage.h"
 #import "OSEPower.h"
 
+//-------------------------------------------------------------------------------
+#pragma mark - Notifications
+//-------------------------------------------------------------------------------
 NSString *OSEPowerPropertiesDidChangeNotification = @"OSEPowerPropertiesDidChangeNotification";
 NSString *OSEPowerLidDidChangeNotification = @"OSEPowerLidDidChangeNotification";
 NSString *OSEPowerDeviceDidAddNotification = @"OSEPowerDeviceDidAddNotification";
 NSString *OSEPowerDeviceDidRemoveNotification = @"OSEPowerDeviceDidRemoveNotification";
 
+
+//-------------------------------------------------------------------------------
+#pragma mark - OSEPower implementation
+//-------------------------------------------------------------------------------
 @implementation OSEPower (Private)
 
 - (id)_propertyValueWithName:(NSString *)propertyName ofClass:(Class)resultClass 
@@ -71,11 +78,12 @@ NSString *OSEPowerDeviceDidRemoveNotification = @"OSEPowerDeviceDidRemoveNotific
 
 - (void)dealloc
 {
+  NSDebugLLog(@"DBus", @"OSEPower: dealloc");
   [super dealloc];
 }
 
 //-------------------------------------------------------------------------------
-// Battery
+#pragma mark - Battery
 //-------------------------------------------------------------------------------
 // TODO
 - (unsigned int)batteryLife
@@ -102,16 +110,8 @@ NSString *OSEPowerDeviceDidRemoveNotification = @"OSEPowerDeviceDidRemoveNotific
 }
 
 //-------------------------------------------------------------------------------
-// Laptop lid
+#pragma mark - Laptop lid
 //-------------------------------------------------------------------------------
-+ (BOOL)isLidClosed
-{
-  OSEPower *power = [OSEPower new];
-  BOOL isLidClosed = [power isLidClosed];
-  [power release];
-  return isLidClosed;
-}
-
 - (BOOL)isLidPresent
 {
   BOOL isLidPresent = NO;
@@ -139,7 +139,7 @@ NSString *OSEPowerDeviceDidRemoveNotification = @"OSEPowerDeviceDidRemoveNotific
 }
 
 //-------------------------------------------------------------------------------
-// UPower D-Bus events
+#pragma mark - UPower D-Bus events
 //-------------------------------------------------------------------------------
 - (void)handleLidNotification:(NSNotification *)aNotif
 {

--- a/Frameworks/SystemKit/OSEPower.m
+++ b/Frameworks/SystemKit/OSEPower.m
@@ -92,7 +92,8 @@ static OSEPower *systemPower = nil;
 
 - (void)dealloc
 {
-  NSDebugLLog(@"DBus", @"OSEPower: -dealloc (retain count: %lu)", [self retainCount]);
+  NSDebugLLog(@"dealloc", @"OSEPower: -dealloc (retain count: %lu) (connection retain count: %lu)",
+              [self retainCount], [self.connection retainCount]);
   systemPower = nil;
   [super dealloc];
 }

--- a/Frameworks/SystemKit/OSEScreen.h
+++ b/Frameworks/SystemKit/OSEScreen.h
@@ -66,7 +66,7 @@
 #import <Foundation/Foundation.h>
 #import <AppKit/NSColor.h>
 
-#import <SystemKit/OSEPower.h>
+@class OSEPower;
 
 @class OSEDisplay;
 

--- a/Frameworks/SystemKit/OSEScreen.h
+++ b/Frameworks/SystemKit/OSEScreen.h
@@ -65,11 +65,9 @@
 
 #import <Foundation/Foundation.h>
 #import <AppKit/NSColor.h>
-
-@class OSEPower;
+#import <SystemKit/OSEPower.h>
 
 @class OSEDisplay;
-
 
 @interface OSEScreen : NSObject
 {

--- a/Frameworks/SystemKit/OSEScreen.h
+++ b/Frameworks/SystemKit/OSEScreen.h
@@ -88,8 +88,10 @@
   NSSize sizeInPixels, sizeInMilimeters;
 }
 
-// + (id)sharedScreen;
++ (id)sharedScreen;
 - (void)setUseAutosave:(BOOL)yn;
+
+- (BOOL)isLidClosed;
 
 - (XRRScreenResources *)randrScreenResources;
 - (void)randrUpdateScreenResources;

--- a/Frameworks/SystemKit/OSEScreen.h
+++ b/Frameworks/SystemKit/OSEScreen.h
@@ -61,19 +61,22 @@
  - Providing mechanism to do various display manipulation: fading, switching
    to console, power management.
  */
+#include <X11/extensions/Xrandr.h>
 
 #import <Foundation/Foundation.h>
 #import <AppKit/NSColor.h>
 
-#import <X11/extensions/Xrandr.h>
+#import <SystemKit/OSEPower.h>
 
 @class OSEDisplay;
+
 
 @interface OSEScreen : NSObject
 {
  @private
   Display *xDisplay;
   Window xRootWindow;
+  OSEPower *systemPower;
 
   Pixmap background_pixmap;
   GC background_gc;

--- a/Frameworks/SystemKit/OSEScreen.h
+++ b/Frameworks/SystemKit/OSEScreen.h
@@ -88,7 +88,7 @@
   NSSize sizeInPixels, sizeInMilimeters;
 }
 
-+ (id)sharedScreen;
+// + (id)sharedScreen;
 - (void)setUseAutosave:(BOOL)yn;
 
 - (XRRScreenResources *)randrScreenResources;

--- a/Frameworks/SystemKit/OSEScreen.m
+++ b/Frameworks/SystemKit/OSEScreen.m
@@ -69,7 +69,7 @@ NSString *OSEDisplayPropertiesKey = @"Properties";
 NSString *OSEScreenDidChangeNotification = @"OSEScreenDidChangeNotification";
 NSString *OSEScreenDidUpdateNotification = @"OSEScreenDidUpdateNotification";
 
-// static OSEScreen *systemScreen = nil;
+static OSEScreen *systemScreen = nil;
 
 @interface OSEScreen (Private)
 - (NSSize)_sizeInPixels;
@@ -251,14 +251,14 @@ NSString *OSEScreenDidUpdateNotification = @"OSEScreenDidUpdateNotification";
 
 @implementation OSEScreen
 
-// + (id)sharedScreen
-// {
-//   if (systemScreen == nil) {
-//     systemScreen = [[OSEScreen alloc] init];
-//   }
++ (id)sharedScreen
+{
+  if (systemScreen == nil) {
+    systemScreen = [[OSEScreen alloc] init];
+  }
 
-//   return systemScreen;
-// }
+  return systemScreen;
+}
 
 - (void)dealloc
 {
@@ -285,7 +285,7 @@ NSString *OSEScreenDidUpdateNotification = @"OSEScreenDidUpdateNotification";
   [systemDisplays release];
   [updateScreenLock release];
   [systemPower release];
-  // systemScreen = nil;
+  systemScreen = nil;
 
   [super dealloc];
 }
@@ -295,9 +295,9 @@ NSString *OSEScreenDidUpdateNotification = @"OSEScreenDidUpdateNotification";
   int event_base, error_base;
   int major_version, minor_version;
 
-  // if (systemScreen != nil) {
-  //   return systemScreen;
-  // }
+  if (systemScreen != nil) {
+    return systemScreen;
+  }
 
   xDisplay = XOpenDisplay(getenv("DISPLAY"));
   if (!xDisplay) {
@@ -344,11 +344,10 @@ NSString *OSEScreenDidUpdateNotification = @"OSEScreenDidUpdateNotification";
   systemPower = [OSEPower sharedPower];
 
   // Workspace Manager notification sent as a reaction to XRRScreenChangeNotify
-  [[NSDistributedNotificationCenter defaultCenter]
-    addObserver:self
-       selector:@selector(randrScreenDidChange:)
-           name:OSEScreenDidChangeNotification
-         object:nil];
+  [[NSDistributedNotificationCenter defaultCenter] addObserver:self
+                                                      selector:@selector(randrScreenDidChange:)
+                                                          name:OSEScreenDidChangeNotification
+                                                        object:nil];
 
   return self;
 }
@@ -356,6 +355,11 @@ NSString *OSEScreenDidUpdateNotification = @"OSEScreenDidUpdateNotification";
 - (void)setUseAutosave:(BOOL)yn
 {
   useAutosave = yn;
+}
+
+- (BOOL)isLidClosed
+{
+  return [systemPower isLidClosed];
 }
 
 //

--- a/Frameworks/SystemKit/OSEScreen.m
+++ b/Frameworks/SystemKit/OSEScreen.m
@@ -284,7 +284,10 @@ static OSEScreen *systemScreen = nil;
 
   [systemDisplays release];
   [updateScreenLock release];
+
+  [systemPower stopEventsMonitor];
   [systemPower release];
+
   systemScreen = nil;
 
   [super dealloc];

--- a/Frameworks/SystemKit/OSEScreen.m
+++ b/Frameworks/SystemKit/OSEScreen.m
@@ -43,7 +43,6 @@ typedef struct _XRRScreenResources {
 #import "OSEDisplay.h"
 #import "OSEScreen.h"
 #import "OSEMouse.h"
-#import "OSEPower.h"
 
 // NXGlobalDomain key
 NSString *OSEDesktopBackgroundColor = @"DesktopBackgroundColor";

--- a/Frameworks/SystemKit/OSEScreen.m
+++ b/Frameworks/SystemKit/OSEScreen.m
@@ -1001,12 +1001,12 @@ static OSEScreen *systemScreen = nil;
 - (BOOL)validateLayout:(NSArray *)layout
 {
   NSDictionary	*gamma;
-  NSString	*dName;
+  // NSString	*dName;
   NSRect	dFrame;
   NSDictionary	*resolution;
   
   for (NSDictionary *d in layout) {
-    dName = [d objectForKey:OSEDisplayNameKey];
+    // dName = [d objectForKey:OSEDisplayNameKey];
 
     // ID
     if (![self displayWithID:[d objectForKey:OSEDisplayIDKey]]) {

--- a/Frameworks/SystemKit/OSEScreen.m
+++ b/Frameworks/SystemKit/OSEScreen.m
@@ -43,6 +43,7 @@ typedef struct _XRRScreenResources {
 #import "OSEDisplay.h"
 #import "OSEScreen.h"
 #import "OSEMouse.h"
+#import "OSEPower.h"
 
 // NXGlobalDomain key
 NSString *OSEDesktopBackgroundColor = @"DesktopBackgroundColor";

--- a/Frameworks/SystemKit/OSEScreen.m
+++ b/Frameworks/SystemKit/OSEScreen.m
@@ -267,8 +267,12 @@ NSString *OSEScreenDidUpdateNotification = @"OSEScreenDidUpdateNotification";
   [[NSDistributedNotificationCenter defaultCenter] removeObserver:self];
 
   if (background_pixmap != None && backgroundPixmapOwner == self) {
-    XFree(&background_pixmap);
+    // From XChangeProperty(3): "The lifetime of a property is not tied to the storing client.
+    // Properties remain until explicitly deleted, until the window is destroyed, or until the
+    // server resets.". So we don't need to free `background_pixmap` property.
+    //   XFree(&background_pixmap);
     background_pixmap = None;
+    backgroundPixmapOwner = nil;
   }
   if (background_gc != None) {
     XFreeGC(xDisplay, background_gc);

--- a/Frameworks/SystemKit/OSEScreen.m
+++ b/Frameworks/SystemKit/OSEScreen.m
@@ -42,7 +42,6 @@ typedef struct _XRRScreenResources {
 #import "OSEDefaults.h"
 #import "OSEDisplay.h"
 #import "OSEScreen.h"
-#import "OSEPower.h"
 #import "OSEMouse.h"
 
 // NXGlobalDomain key
@@ -309,6 +308,8 @@ static OSEScreen *systemScreen = nil;
   background_pixmap = None;
   background_gc = None;
 
+  systemPower = [OSEPower new];
+
   // Workspace Manager notification sent as a reaction to XRRScreenChangeNotify
   [[NSDistributedNotificationCenter defaultCenter]
     addObserver:self
@@ -342,6 +343,7 @@ static OSEScreen *systemScreen = nil;
 
   [systemDisplays release];
   [updateScreenLock release];
+  [systemPower release];
 
   [super dealloc];
 }
@@ -896,7 +898,7 @@ static OSEScreen *systemScreen = nil;
     [d setObject:[resolution objectForKey:OSEDisplayRateKey]
           forKey:OSEDisplayFrameRateKey];
 
-    if ([display isBuiltin] && [OSEPower isLidClosed]) {
+    if ([display isBuiltin] && [systemPower isLidClosed]) {
       [d setObject:@"NO" forKey:OSEDisplayIsActiveKey];
       [d setObject:@"NO" forKey:OSEDisplayIsMainKey];
     }
@@ -924,7 +926,7 @@ static OSEScreen *systemScreen = nil;
     [layout addObject:d];
     [d release];
 
-    if (arrange && (![display isBuiltin] || ![OSEPower isLidClosed])) {
+    if (arrange && (![display isBuiltin] || ![systemPower isLidClosed])) {
       origin.x +=
         NSSizeFromString([resolution objectForKey:OSEDisplaySizeKey]).width;
     }
@@ -1085,7 +1087,7 @@ static OSEScreen *systemScreen = nil;
     // Set resolution to displays marked as active in layout
     if ([[displayLayout objectForKey:OSEDisplayIsActiveKey]
             isEqualToString:@"YES"]) {
-      if ([display isBuiltin] && [OSEPower isLidClosed]) {
+      if ([display isBuiltin] && [systemPower isLidClosed]) {
         // set 'frame' to preserve it in 'hiddenFrame' on deactivate
         frame = NSRectFromString([displayLayout
                                          objectForKey:OSEDisplayFrameKey]);

--- a/Frameworks/SystemKit/OSEScreen.m
+++ b/Frameworks/SystemKit/OSEScreen.m
@@ -1001,12 +1001,12 @@ static OSEScreen *systemScreen = nil;
 - (BOOL)validateLayout:(NSArray *)layout
 {
   NSDictionary	*gamma;
-  // NSString	*dName;
+  NSString	*dName;
   NSRect	dFrame;
   NSDictionary	*resolution;
   
   for (NSDictionary *d in layout) {
-    // dName = [d objectForKey:OSEDisplayNameKey];
+    dName = [d objectForKey:OSEDisplayNameKey];
 
     // ID
     if (![self displayWithID:[d objectForKey:OSEDisplayIDKey]]) {

--- a/Frameworks/SystemKit/OSEUDisksAdaptor.h
+++ b/Frameworks/SystemKit/OSEUDisksAdaptor.h
@@ -101,7 +101,8 @@ extern NSString *OSEUDisksInterfacesDidRemoveNotification;
 - (NSMutableDictionary *)properties;
 
 - (id)initWithProperties:(NSDictionary *)properties
-              objectPath:(NSString *)path;
+              objectPath:(NSString *)path
+                 adaptor:(OSEUDisksAdaptor *)adaptor;
 - (void)setProperty:(NSString *)property
               value:(NSString *)value
       interfaceName:(NSString *)interface;

--- a/Frameworks/SystemKit/OSEUDisksAdaptor.h
+++ b/Frameworks/SystemKit/OSEUDisksAdaptor.h
@@ -119,3 +119,20 @@ extern NSString *OSEUDisksInterfacesDidRemoveNotification;
 - (void)_dumpProperties;
 
 @end
+
+@interface OSEUDisksAdaptor (Utility)
+- (OSEUDisksObject)_objectTypeForPath:(NSString *)objectPath;
+
+- (NSMutableDictionary *)_parsePropertiesSection:(NSArray *)sectionProperties;
+- (NSMutableDictionary *)_parseDriveProperties:(NSArray *)objectProperties;
+
+- (void)_parseDrive:(NSString *)objectPath withProperties:(NSArray *)objectProperties;
+- (void)_parseBlockDevice:(NSString *)objectPath withProperties:(NSArray *)objectProperties;
+- (void)_parseObject:(NSString *)objectPath withProperties:(NSArray *)objectProperties;
+
+- (void)_removeObject:(NSString *)objectPath andNotify:(BOOL)notify;
+
+- (void)_registerDrive:(NSString *)objectPath andNotify:(BOOL)notify;
+- (void)_registerBlockDevice:(NSString *)objectPath andNotify:(BOOL)notify;
+- (void)_registerObjects;
+@end

--- a/Frameworks/SystemKit/OSEUDisksAdaptor.h
+++ b/Frameworks/SystemKit/OSEUDisksAdaptor.h
@@ -66,9 +66,9 @@ extern NSString *OSEUDisksInterfacesDidRemoveNotification;
   // List of /org/freedesktop/UDisks2/jobs objects
   NSMutableDictionary *jobsCache;
   
-  // List of OSEOSEUDisksVolume objects with D-Bus object path as key
+  // List of OSEUDisksVolume objects with D-Bus object path as key
   NSMutableDictionary *volumes;
-  // List of OSEOSEUDisksDrive objects with D-Bus object path as key
+  // List of OSEUDisksDrive objects with D-Bus object path as key
   NSMutableDictionary *drives;
   
   NSMutableArray *drivesToCleanup;  // unsafely detached drives

--- a/Frameworks/SystemKit/OSEUDisksAdaptor.h
+++ b/Frameworks/SystemKit/OSEUDisksAdaptor.h
@@ -103,6 +103,9 @@ extern NSString *OSEUDisksInterfacesDidRemoveNotification;
 - (id)initWithProperties:(NSDictionary *)properties
               objectPath:(NSString *)path
                  adaptor:(OSEUDisksAdaptor *)adaptor;
+- (void)setSignalsObserving;
+- (void)removeSignalsObserving;
+
 - (void)setProperty:(NSString *)property
               value:(NSString *)value
       interfaceName:(NSString *)interface;
@@ -110,6 +113,7 @@ extern NSString *OSEUDisksInterfacesDidRemoveNotification;
            interfaceName:(NSString *)interface;
 - (id)propertyForKey:(NSString *)key interface:(NSString *)interface;
 - (BOOL)boolPropertyForKey:(NSString *)key interface:(NSString *)interface;
+
 
 // This is for debug
 - (void)_dumpProperties;

--- a/Frameworks/SystemKit/OSEUDisksAdaptor.h
+++ b/Frameworks/SystemKit/OSEUDisksAdaptor.h
@@ -53,10 +53,6 @@ typedef enum {
 // /org/freedesktop/UDisks2/jobs
 #define JOB_INTERFACE       @"org.freedesktop.UDisks2.Job"
 
-extern NSString *OSEUDisksPropertiesDidChangeNotification;
-extern NSString *OSEUDisksInterfacesDidAddNotification;
-extern NSString *OSEUDisksInterfacesDidRemoveNotification;
-
 @interface OSEUDisksAdaptor : OSEBusService <DBus_ObjectManager, MediaManager>
 {
   // /org/freedesktop/UDisks2/block_devices/

--- a/Frameworks/SystemKit/OSEUDisksAdaptor.m
+++ b/Frameworks/SystemKit/OSEUDisksAdaptor.m
@@ -652,10 +652,9 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
     // of application. Only OSEMediaVolume* notification will be sent.
     if ([name isEqualToString:@"Mount"] || [name isEqualToString:@"Unmount"]) {
       [info setObject:[object UNIXDevice] forKey:@"UNIXDevice"];
-
       if ([name isEqualToString:@"Mount"] && !failed) {
         if ([object mountPoints].count > 0) {
-          [info setObject:[object mountPoints] forKey:@"MountPoint"];
+          [info setObject:[object mountPoints].firstObject forKey:@"MountPoint"];
         }
         [notificationCenter postNotificationName:OSEMediaVolumeDidMountNotification
                                           object:self
@@ -719,7 +718,7 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
 
     OSEUDisksDrive *drive = [volume drive];
     if (volume.isFilesystem && (drive.isRemovable || (drive.isMediaRemovable && drive.hasMedia))) {
-      [mountPaths addObject:[volume mountPoints]];
+      [mountPaths addObject:[volume mountPoints].firstObject];
     }
   }
 

--- a/Frameworks/SystemKit/OSEUDisksAdaptor.m
+++ b/Frameworks/SystemKit/OSEUDisksAdaptor.m
@@ -622,13 +622,15 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
 {
   OSEUDisksVolume *volume = nil;
   NSString *commonPath = nil;
+  NSString *longestPath = nil;
 
   // Find longest mount point for path
   for (OSEUDisksVolume *vol in [self mountedVolumes]) {
     for (NSString *mp in [vol mountPoints]) {
       commonPath = NXTIntersectionPath(filesystemPath, mp);
-      if ([commonPath isEqualToString:mp] && ([commonPath length] >= [mp length])) {
+      if ([commonPath isEqualToString:mp] && ([commonPath length] >= [longestPath length])) {
         volume = vol;
+        longestPath = [NSString stringWithString:mp];
       }
     }
   }

--- a/Frameworks/SystemKit/OSEUDisksAdaptor.m
+++ b/Frameworks/SystemKit/OSEUDisksAdaptor.m
@@ -538,20 +538,22 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
 //-------------------------------------------------------------------------------
 - (void)dealloc
 {
-  NSDebugLLog(@"dealloc", @"OSEUDisksAdaptor: dealloc (retain count: %lu)", [self retainCount]);
-
-  [self removeSignalsMonitoring];
+  NSDebugLLog(@"dealloc", @"OSEUDisksAdaptor: -dealloc (retain count: %lu)", [self retainCount]);
 
   [udisksBlockDevicesCache release];
   [OSEUDisksDrivesCache release];
 
+  NSDebugLLog(@"dealloc", @"OSEUDisksAdaptor: -dealloc - `volumes` retain count %lu.", [volumes retainCount]);
   [volumes release];
   [drives release];
   [jobsCache release];
 
   // OSEUDisksAdaptor is the main owner of connection to UDisks2 D-Bus service (OSEBusConnection) - release it.
-  [self.connection release];
+  // [self.connection release];
 
+  [self removeSignalsMonitoring];
+
+  NSDebugLLog(@"dealloc", @"OSEUDisksAdaptor: -dealloc - end of routine.");
   [super dealloc];
 }
 

--- a/Frameworks/SystemKit/OSEUDisksAdaptor.m
+++ b/Frameworks/SystemKit/OSEUDisksAdaptor.m
@@ -20,6 +20,7 @@
 //
 
 #import <SystemKit/OSEFileManager.h>
+#include "Foundation/NSDictionary.h"
 #import <SystemKit/OSEBusMessage.h>
 
 #import "OSEUDisksDrive.h"
@@ -888,8 +889,9 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
 // Async - OK.
 - (void)ejectAllRemovables
 {
+  NSDictionary *_drives;
   OSEUDisksDrive *drive;
-  OSEUDisksVolume *volume;
+  // OSEUDisksVolume *volume;
 
   // Loops first...
   // for (NSString *key in [volumes allKeys]) {
@@ -900,13 +902,15 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
   //   }
   // }
 
-  //...drives then
-  for (NSString *key in [drives allKeys]) {
+  //...drives then. Drives could disappear during eject/poweroff so copy
+  _drives = [drives copy];
+  for (NSString *key in [_drives allKeys]) {
     drive = drives[key];
     if ([drive isRemovable]) {
       [drive unmountVolumesAndDetach];
     }
   }
+  [_drives release];
 }
 
 - (BOOL)mountImageMediaFileAtPath:(NSString *)imageFile

--- a/Frameworks/SystemKit/OSEUDisksAdaptor.m
+++ b/Frameworks/SystemKit/OSEUDisksAdaptor.m
@@ -506,6 +506,20 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
 //-------------------------------------------------------------------------------
 #pragma mark - Init
 //-------------------------------------------------------------------------------
+- (void)dealloc
+{
+  NSDebugLLog(@"dealloc", @"OSEUDisksAdaptor: dealloc (retain count: %lu)", [self retainCount]);
+
+  [udisksBlockDevicesCache release];
+  [OSEUDisksDrivesCache release];
+
+  [volumes release];
+  [drives release];
+  [jobsCache release];
+
+  [super dealloc];
+}
+
 - (id)init
 {
   [super init];
@@ -535,19 +549,6 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
 #endif
 
   return self;
-}
-
-- (void)dealloc
-{
-  NSDebugLLog(@"OSEUDisksAdaptor", @"OSEUDisksAdaptor: dealloc");
-
-  [udisksBlockDevicesCache release];
-  [OSEUDisksDrivesCache release];
-
-  [volumes release];
-  [drives release];
-
-  [super dealloc];
 }
 
 //-------------------------------------------------------------------------------
@@ -651,7 +652,9 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
   }
 
   if ([status isEqualToString:@"Started"]) {
-    [notificationCenter postNotificationName:OSEMediaOperationDidStartNotification object:self userInfo:info];
+    [notificationCenter postNotificationName:OSEMediaOperationDidStartNotification
+                                      object:self
+                                    userInfo:info];
   } else {
     // "Completed" - operation was started by framework methods.
     // OSEMediaVolume* and OSEMediaOperation* notifications will be sent.
@@ -662,8 +665,9 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
 
       if ([name isEqualToString:@"Mount"] && !failed) {
         [info setObject:[object mountPoints] forKey:@"MountPoint"];
-        [self performSelectorOnMainThread:@selector(postVolumeDidMountNotification:) withObject:info waitUntilDone:YES];
-        // [notificationCenter postNotificationName:OSEMediaVolumeDidMountNotification object:self userInfo:info];
+        [notificationCenter postNotificationName:OSEMediaVolumeDidMountNotification
+                                          object:self
+                                        userInfo:info];
       } else if ([name isEqualToString:@"Unmount"] && !failed) {
         NSString *mp = [object mountPoints][0];
 
@@ -673,12 +677,16 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
           mp = [object propertyForKey:@"OldMountPoint" interface:FS_INTERFACE];
         }
         [info setObject:mp forKey:@"MountPoint"];
-        [notificationCenter postNotificationName:OSEMediaVolumeDidUnmountNotification object:self userInfo:info];
+        [notificationCenter postNotificationName:OSEMediaVolumeDidUnmountNotification
+                                          object:self
+                                        userInfo:info];
       }
     }
 
     if ([status isEqualToString:@"Completed"]) {
-      [notificationCenter postNotificationName:OSEMediaOperationDidEndNotification object:self userInfo:info];
+      [notificationCenter postNotificationName:OSEMediaOperationDidEndNotification
+                                        object:self
+                                      userInfo:info];
     }
   }
 }

--- a/Frameworks/SystemKit/OSEUDisksAdaptor.m
+++ b/Frameworks/SystemKit/OSEUDisksAdaptor.m
@@ -560,13 +560,12 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
 // That's why we iterate registered diskVolumes.
 - (NSDictionary *)availableVolumesForDrive:(NSString *)driveObjectPath
 {
-  NSArray *volumePaths = [volumes allKeys];
   OSEUDisksVolume *volume;
-  NSMutableDictionary *driveVolumes = [NSMutableDictionary new];
+  NSMutableDictionary *driveVolumes = [NSMutableDictionary dictionary];
 
-  for (NSString *path in volumePaths) {
+  for (NSString *path in [volumes allKeys]) {
     volume = [volumes objectForKey:path];
-    if ([[volume driveObjectPath] isEqualToString:driveObjectPath]) {
+    if ([volume.drive.objectPath isEqualToString:driveObjectPath]) {
       [driveVolumes setObject:volume forKey:path];
     }
   }

--- a/Frameworks/SystemKit/OSEUDisksAdaptor.m
+++ b/Frameworks/SystemKit/OSEUDisksAdaptor.m
@@ -508,7 +508,7 @@ static NSMutableDictionary *_dictionaryFromUDisksObject(UDisksObject *object)
 
       if (notify)
         {
-          [notificationCenter postNotificationName:OSEDiskAppeared
+          [notificationCenter postNotificationName:OSEMediaDriveDidAddNotification
                                             object:self
                                           userInfo:driveProps];
         }
@@ -527,12 +527,12 @@ static NSMutableDictionary *_dictionaryFromUDisksObject(UDisksObject *object)
       
       if (notify)
         {
-          [notificationCenter postNotificationName:NXVolumeAppeared
+          [notificationCenter postNotificationName:OSEMediaVolumeDidAddNotification
                                             object:self
                                           userInfo:volumeProps];
           if ([volume isFilesystem])
             {
-              // Emits NXVolumeMounted notification
+              // Emits OSEMediaVolumeDidMountNotification notification
               // We are called by event of inserted device not during initial
               // registraion of objects.
               [volume mount:NO];
@@ -626,8 +626,8 @@ static NSMutableDictionary *_dictionaryFromUDisksObject(UDisksObject *object)
                                  @"Info",       @"MessageType",
                                @"Eject Disk", @"MessageTitle",
                                message,       @"Message", nil];
-          // OSEDiskDisappeared notification
-          [notificationCenter postNotificationName:OSEDiskDisappeared
+          // OSEMediaDriveDidRemoveNotification notification
+          [notificationCenter postNotificationName:OSEMediaDriveDidRemoveNotification
                                             object:self
                                           userInfo:info];
         }
@@ -645,8 +645,8 @@ static NSMutableDictionary *_dictionaryFromUDisksObject(UDisksObject *object)
           [drivesToCleanup addObject:[[volume drive] objectPath]];
         }
       
-      // NXVolumeDisappeared notification
-      [notificationCenter postNotificationName:NXVolumeDisappeared
+      // OSEMediaVolumeDidRemoveNotification notification
+      [notificationCenter postNotificationName:OSEMediaVolumeDidRemoveNotification
                                         object:self
                                       userInfo:[volume properties]];
 
@@ -716,7 +716,7 @@ static NSMutableDictionary *_dictionaryFromUDisksObject(UDisksObject *object)
 
   if ([status isEqualToString:@"Started"])
     {
-      [notificationCenter postNotificationName:OSEMediaOperationDidStart
+      [notificationCenter postNotificationName:OSEMediaOperationDidStartNotification
                                         object:self
                                       userInfo:info];
     }
@@ -733,7 +733,7 @@ static NSMutableDictionary *_dictionaryFromUDisksObject(UDisksObject *object)
           if ([name isEqualToString:@"Mount"] && !failed)
             {
               [info setObject:[object mountPoints] forKey:@"MountPoint"];
-              [notificationCenter postNotificationName:NXVolumeMounted
+              [notificationCenter postNotificationName:OSEMediaVolumeDidMountNotification
                                                 object:self
                                               userInfo:info];
             }
@@ -749,7 +749,7 @@ static NSMutableDictionary *_dictionaryFromUDisksObject(UDisksObject *object)
                                     interface:FS_INTERFACE];
                 }
               [info setObject:mp forKey:@"MountPoint"];
-              [notificationCenter postNotificationName:NXVolumeUnmounted
+              [notificationCenter postNotificationName:OSEMediaVolumeDidUnmountNotification
                                                 object:self
                                               userInfo:info];
             }
@@ -757,7 +757,7 @@ static NSMutableDictionary *_dictionaryFromUDisksObject(UDisksObject *object)
 
       if ([status isEqualToString:@"Completed"])
         {
-          [notificationCenter postNotificationName:OSEMediaOperationDidEnd
+          [notificationCenter postNotificationName:OSEMediaOperationDidEndNotification
                                             object:self
                                           userInfo:info];
         }

--- a/Frameworks/SystemKit/OSEUDisksAdaptor.m
+++ b/Frameworks/SystemKit/OSEUDisksAdaptor.m
@@ -362,23 +362,39 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
   //                           selector:@selector(handlePropertiesChangedSignal:)
   //                             signal:@"PropertiesChanged"
   //                             object:self.objectPath
-  //                          interface:@"org.freedesktop.DBus.Properties"
-  //                       notification:OSEUDisksPropertiesDidChangeNotification];
+  //                          interface:@"org.freedesktop.DBus.Properties"];
   
   [self.connection addSignalObserver:self
                             selector:@selector(handleInterfacesAdeddSignal:)
                               signal:@"InterfacesAdded"
                               object:self.objectPath
-                           interface:@"org.freedesktop.DBus.ObjectManager"
-                        notification:OSEUDisksInterfacesDidAddNotification];
+                           interface:@"org.freedesktop.DBus.ObjectManager"];
   
   [self.connection addSignalObserver:self
                             selector:@selector(handleInterfacesRemovedSignal:)
                               signal:@"InterfacesRemoved"
                               object:self.objectPath
-                           interface:@"org.freedesktop.DBus.ObjectManager"
-                        notification:OSEUDisksInterfacesDidRemoveNotification];
+                           interface:@"org.freedesktop.DBus.ObjectManager"];
 }
+
+- (void)removeSignalsMonitoring
+{
+  // [self.connection removeSignalObserver:self
+  //                                signal:@"PropertiesChanged"
+  //                                object:self.objectPath
+  //                             interface:@"org.freedesktop.DBus.Properties"];
+
+  [self.connection removeSignalObserver:self
+                                 signal:@"InterfacesAdded"
+                                 object:self.objectPath
+                              interface:@"org.freedesktop.DBus.ObjectManager"];
+
+  [self.connection removeSignalObserver:self
+                                 signal:@"InterfacesRemoved"
+                                 object:self.objectPath
+                              interface:@"org.freedesktop.DBus.ObjectManager"];
+}
+
 
 - (void)handlePropertiesChangedSignal:(NSDictionary *)info
 {
@@ -523,6 +539,8 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
 - (void)dealloc
 {
   NSDebugLLog(@"dealloc", @"OSEUDisksAdaptor: dealloc (retain count: %lu)", [self retainCount]);
+
+  [self removeSignalsMonitoring];
 
   [udisksBlockDevicesCache release];
   [OSEUDisksDrivesCache release];

--- a/Frameworks/SystemKit/OSEUDisksAdaptor.m
+++ b/Frameworks/SystemKit/OSEUDisksAdaptor.m
@@ -430,7 +430,7 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
         [volume _dumpProperties];
         [properties release];
       }
-      // [[volumes objectForKey:objectPath] mount:YES];
+      [[volumes objectForKey:objectPath] mount:YES];
     } break;
     case OSEUDisksJobObject: {
       // TODO

--- a/Frameworks/SystemKit/OSEUDisksAdaptor.m
+++ b/Frameworks/SystemKit/OSEUDisksAdaptor.m
@@ -489,9 +489,6 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
   [drives release];
   [jobsCache release];
 
-  // OSEUDisksAdaptor is the main owner of connection to UDisks2 D-Bus service (OSEBusConnection) - release it.
-  // [self.connection release];
-
   [self removeSignalsMonitoring];
 
   NSDebugLLog(@"dealloc", @"OSEUDisksAdaptor: -dealloc - end of routine.");
@@ -595,7 +592,7 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
     }
   }
 
-  NSDebugLLog(@"UDisks", @"Longest MP: %@ for path %@", [volume mountPoints], filesystemPath);
+  // NSDebugLLog(@"UDisks", @"Longest MP: %@ for path %@", [volume mountPoints], filesystemPath);
 
   return volume;
 }
@@ -695,10 +692,10 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
   NSMutableArray *mountPaths = [NSMutableArray array];
 
   for (OSEUDisksVolume *volume in mountedVolumes) {
-    NSDebugLLog(@"UDisks", @"OSEUDisksAdaptor: mountedRemovableMedia check: %@ (%@)",
-                [volume mountPoints],
-                [[[[volume drive] properties] objectForKey:@"org.freedesktop.UDisks2.Drive"]
-                    objectForKey:@"Id"]);
+    // NSDebugLLog(@"UDisks", @"OSEUDisksAdaptor: mountedRemovableMedia check: %@ (%@)",
+    //             [volume mountPoints],
+    //             [[[[volume drive] properties] objectForKey:@"org.freedesktop.UDisks2.Drive"]
+    //                 objectForKey:@"Id"]);
 
     OSEUDisksDrive *drive = [volume drive];
     if (volume.isFilesystem && (drive.isRemovable || (drive.isMediaRemovable && drive.hasMedia))) {
@@ -750,6 +747,7 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
   NSMutableArray *mountPoints = [NSMutableArray new];
   OSEUDisksDrive *drive;
   OSEUDisksVolume *volume;
+  NSString *mountPoint;
 
   // for (NSString *key in [drives allKeys]) {
   //   drive = drives[key];
@@ -769,9 +767,11 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
   for (NSString *key in [volumes allKeys]) {
     volume = volumes[key];
     drive = volume.drive;
-    if ([drive isRemovable] && [volume isFilesystem]) {
-      // [mountPoints addObjectsFromArray:[volume mount:wait]];
-      [mountPoints addObject:[volume mount:YES]];
+    if (drive && [drive isRemovable] && [volume isFilesystem]) {
+      mountPoint = [volume mount:wait];
+      if (mountPoint) {
+        [mountPoints addObject:mountPoint];
+      }
     }
   }
 

--- a/Frameworks/SystemKit/OSEUDisksAdaptor.m
+++ b/Frameworks/SystemKit/OSEUDisksAdaptor.m
@@ -19,670 +19,601 @@
 // Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111 USA.
 //
 
-#ifdef WITH_UDISKS
+#import <SystemKit/OSEFileManager.h>
+#import <SystemKit/OSEBusMessage.h>
 
-#import "OSEFileManager.h"
 #import "OSEUDisksDrive.h"
 #import "OSEUDisksVolume.h"
 
-static NSNotificationCenter *notificationCenter;
+#import "OSEUDisksAdaptor.h"
 
-static GMainLoop       *glib_mainloop;
-static UDisksClient    *udisks_client; // used by UDisks callback functions
-static OSEUDisksAdaptor *udisksAdaptor; // used by UDisks callback functions
+// Signals
+NSString *OSEUDisksInterfacesDidAddNotification = @"OSEUDisksInterfacesDidAddNotification";
+NSString *OSEUDisksInterfacesDidRemoveNotification = @"OSEUDisksInterfacesDidRemoveNotification";
+NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidChangeNotification";
 
-NSString *GSTR_2STR(const gchar *s)
+@interface OSEUDisksAdaptor (Private)
+- (OSEUDisksObject)_objectTypeForPath:(NSString *)objectPath;
+
+- (void)_parseDrive:(NSString *)objectPath withProperties:(NSArray *)objectProperties;
+- (void)_parseBlockDevice:(NSString *)objectPath withProperties:(NSArray *)objectProperties;
+- (void)_parseObject:(NSString *)objectPath withProperties:(NSArray *)objectProperties;
+
+- (void)_removeObject:(NSString *)objectPath andNotify:(BOOL)notify;
+
+- (void)_registerDrive:(NSString *)objectPath andNotify:(BOOL)notify;
+- (void)_registerBlockDevice:(NSString *)objectPath andNotify:(BOOL)notify;
+- (void)_registerObjects;
+@end
+
+@implementation OSEUDisksAdaptor (Private)
+
+- (OSEUDisksObject)_objectTypeForPath:(NSString *)objectPath
 {
-  return [NSString stringWithCString:s];
-}
+  NSArray *pathComponents = [objectPath pathComponents];
+  NSString *objectType = nil;
+  int type = OSEUDisksUnknownObject;
 
-NSArray *GARR_2ARR(const gchar *const*s) // TODO: multiple entries
-{
-  int            el_count = g_strv_length((gchar**)s);
-  int            i;
-  NSMutableArray *array;
-
-  if (el_count == 0)
-    {
-      return nil;
+  if (pathComponents.count > 2) {
+    objectType = [pathComponents objectAtIndex:[pathComponents count] - 2];
+    if ([objectType isEqualToString:@"drives"]) {
+      type = OSEOSEUDisksDriveObject;
+    } else if ([objectType isEqualToString:@"block_devices"]) {
+      type = OSEUDisksBlockObject;
+    } else if ([objectType isEqualToString:@"jobs"]) {
+      type = OSEUDisksJobObject;
     }
-  else if (el_count == 1)
-    {
-      return [NSArray arrayWithObject:[NSString stringWithCString:s[0]]];
+  }
+
+  return type;
+}
+
+#pragma mark - D-Bus objects cache
+
+- (NSMutableDictionary *)_parsePropertiesSection:(NSArray *)sectionProperties
+{
+  NSMutableDictionary *normalizedProperties = [NSMutableDictionary new];
+  for (NSDictionary *prop in sectionProperties) {
+    [normalizedProperties addEntriesFromDictionary:prop];
+  }
+  return normalizedProperties;
+}
+
+- (NSMutableDictionary *)_parseDriveProperties:(NSArray *)objectProperties
+{
+  NSMutableDictionary *driveProperties = [NSMutableDictionary new];
+  NSMutableDictionary *driveSection;
+  NSMutableDictionary *driveAtaSection;
+
+  for (NSDictionary *property in objectProperties) {
+    // .Drive
+    driveSection = [self _parsePropertiesSection:property[DRIVE_INTERFACE]];
+    if (driveSection.allKeys.count > 0) {
+      driveProperties[DRIVE_INTERFACE] = driveSection;
     }
-
-  // multiple entries
-  array = [NSMutableArray new];
-  for (i=0; i < el_count; i++)
-    {
-      [array addObject:[NSString stringWithCString:s[i]]];
+    [driveSection release];
+    // .Drive.Ata
+    driveAtaSection = [self _parsePropertiesSection:property[DRIVE_ATA_INTERFACE]];
+    if (driveAtaSection.allKeys.count > 0) {
+      driveProperties[DRIVE_ATA_INTERFACE] = driveAtaSection;
     }
-
-  return array;
+    [driveAtaSection release];
+  }
+  return driveProperties;
+}
+// `drive` is an array of dictionaries:
+//   org.freedesktop.UDisks2.Drive ({})
+//   org.freedesktop.UDisks2.Drive.Ata ({})
+- (void)_parseDrive:(NSString *)objectPath withProperties:(NSArray *)objectProperties
+{
+  NSMutableDictionary *driveProperties = [self _parseDriveProperties:objectProperties];
+  [OSEUDisksDrivesCache setObject:driveProperties forKey:objectPath];
+  [driveProperties release];
 }
 
-//-----------------------------------------------------------------------
-//--- Monitoring (GLib, GIO, UDisks)
-//-----------------------------------------------------------------------
-
-@implementation OSEUDisksAdaptor (Monitoring)
-
-//--- Modified utility functions from 'udisksctl'
-static gchar *
-variant_to_string_with_indent (GVariant *value,
-                               guint     indent)
+- (NSMutableDictionary *)_parseBlockDeviceProperties:(NSArray *)objectProperties
 {
-  gchar *value_str;
- 
-  if (g_variant_is_of_type (value, G_VARIANT_TYPE_STRING))
-    {
-      value_str = g_variant_dup_string (value, NULL);
+  NSMutableDictionary *blockDeviceProperties = [NSMutableDictionary new];
+  NSMutableDictionary *blockSection;
+  NSMutableDictionary *fileSystemSection;
+  NSMutableDictionary *partitionSection;
+
+  for (NSDictionary *property in objectProperties) {
+    // .Block section
+    blockSection = [self _parsePropertiesSection:property[BLOCK_INTERFACE]];
+    if (blockSection.allKeys.count > 0) {
+      blockDeviceProperties[BLOCK_INTERFACE] = blockSection;
     }
-  else if (g_variant_is_of_type (value, G_VARIANT_TYPE_BYTESTRING))
-    {
-      value_str = g_variant_dup_bytestring (value, NULL);
+    [blockSection release];
+    // .Filesystem section
+    fileSystemSection = [self _parsePropertiesSection:property[FS_INTERFACE]];
+    if (fileSystemSection.allKeys.count > 0) {
+      blockDeviceProperties[FS_INTERFACE] = fileSystemSection;
     }
-  else if (g_variant_is_of_type (value, G_VARIANT_TYPE_STRING_ARRAY) ||
-           g_variant_is_of_type (value, G_VARIANT_TYPE_BYTESTRING_ARRAY))
-    {
-      const gchar **strv;
-      guint m;
-      GString *str;
-      if (g_variant_is_of_type (value, G_VARIANT_TYPE_BYTESTRING_ARRAY))
-        strv = g_variant_get_bytestring_array (value, NULL);
-      else
-        strv = g_variant_get_strv (value, NULL);
-      str = g_string_new (NULL);
-      for (m = 0; strv != NULL && strv[m] != NULL; m++)
-        {
-          if (m > 0)
-            g_string_append_printf (str, "\n%*s", indent, "");
-          g_string_append (str, strv[m]);
-        }
-      value_str = g_string_free (str, FALSE);
-      g_free (strv);
+    [fileSystemSection release];
+    // .Partition section
+    partitionSection = [self _parsePropertiesSection:property[PARTITION_INTERFACE]];
+    if (partitionSection.allKeys.count > 0) {
+      blockDeviceProperties[PARTITION_INTERFACE] = partitionSection;
     }
-  else
-    {
-      gchar *tmp_str;
-      value_str = g_variant_print (value, FALSE);
-      if (value_str[0] == '\'')
-        {
-          tmp_str = strndup(value_str+1, strlen(value_str)-2);
-          free(value_str);
-          value_str = tmp_str;
-        }
+    [partitionSection release];
+  }
+  return blockDeviceProperties;
+}
+- (void)_parseBlockDevice:(NSString *)objectPath withProperties:(NSArray *)objectProperties
+{
+  NSMutableDictionary *blockDeviceProperties = [self _parseBlockDeviceProperties:objectProperties];
+  udisksBlockDevicesCache[objectPath] = blockDeviceProperties;
+  [blockDeviceProperties release];
+}
+
+- (void)_parseObject:(NSString *)objectPath withProperties:(NSArray *)objectProperties
+{
+  NSLog(@"Parsing '%@'", objectPath);
+  switch ([self _objectTypeForPath:objectPath]) {
+    case OSEOSEUDisksDriveObject:
+      [self _parseDrive:objectPath withProperties:objectProperties];
+      break;
+    case OSEUDisksBlockObject:
+      [self _parseBlockDevice:objectPath withProperties:objectProperties];
+      break;
+    case OSEUDisksJobObject:
+      break;
+    default:
+      NSLog(@"OSEUDisksAdaptor Warning: trying to append unknown object type with path '%@'", objectPath);
+  }
+}
+
+#pragma mark - OSEUDisksDrive, OSEUDisksVolume objects
+
+- (void)_removeObject:(NSString *)objectPath andNotify:(BOOL)notify
+{
+  NSLog(@"Removing and unregistering '%@'", objectPath);
+  switch ([self _objectTypeForPath:objectPath]) {
+    case OSEOSEUDisksDriveObject:
+      // [OSEUDisksDrivesCache removeObjectForKey:objectPath];
+      [drives removeObjectForKey:objectPath];
+      if (notify != NO) {
+        [notificationCenter postNotificationName:OSEMediaDriveDidRemoveNotification
+                                          object:self
+                                        userInfo:@{@"ObjectPath" : objectPath}];
+      }
+      break;
+    case OSEUDisksBlockObject:
+      // [udisksBlockDevicesCache removeObjectForKey:objectPath];
+      [volumes removeObjectForKey:objectPath];
+      if (notify != NO) {
+        [notificationCenter postNotificationName:OSEMediaVolumeDidRemoveNotification
+                                          object:self
+                                        userInfo:@{@"ObjectPath" : objectPath}];
+      }
+      break;
+    case OSEUDisksJobObject:
+      // TODO
+      [jobsCache removeObjectForKey:objectPath];
+      break;
+    default:
+      NSLog(@"OSEUDisksAdaptor Warning: trying to remove unknown object type with path %@", objectPath);
+  }
+}
+
+- (void)_registerDrive:(NSString *)objectPath andNotify:(BOOL)notify
+{
+  OSEUDisksDrive *driveInstance;
+  NSDictionary *drive = OSEUDisksDrivesCache[objectPath];
+
+  driveInstance = [[OSEUDisksDrive alloc] initWithProperties:drive objectPath:objectPath];
+  driveInstance.udisksAdaptor = self;
+  [OSEUDisksDrivesCache removeObjectForKey:objectPath];
+
+  [drives setObject:driveInstance forKey:objectPath];
+  [driveInstance release];
+  if (notify != NO) {
+    [notificationCenter postNotificationName:OSEMediaDriveDidAddNotification
+                                      object:self
+                                    userInfo:driveInstance.properties];
+  }
+}
+
+- (void)_registerBlockDevice:(NSString *)objectPath andNotify:(BOOL)notify
+{
+  NSDictionary *blockDevice = udisksBlockDevicesCache[objectPath];
+  NSString *drivePath;
+  OSEUDisksDrive *drive;
+  OSEUDisksVolume *volumeInstance;
+
+  if ([blockDevice[BLOCK_INTERFACE][@"HintIgnore"] boolValue] != NO) {
+    // Ignored devices leaves in the cache
+    return;
+  }
+  volumeInstance = [[OSEUDisksVolume alloc] initWithProperties:blockDevice objectPath:objectPath];
+  volumeInstance.udisksAdaptor = self;
+  [volumes setObject:volumeInstance forKey:objectPath];
+  [udisksBlockDevicesCache removeObjectForKey:objectPath];
+
+  drivePath = blockDevice[BLOCK_INTERFACE][@"Drive"];
+  // NSLog(@"_registerBlockDevice: %@", blockDevice);
+  drive = [drives objectForKey:drivePath];
+  if (drive == nil) {
+    NSLog(@"OSEUDisksAdaptor Warning: no drive with path '%@' found for block device '%@'", drivePath,
+          objectPath);
+    return;
+  }
+  [drive addVolume:volumeInstance withPath:objectPath];
+  volumeInstance.drive = drive;
+  [volumeInstance release];
+
+  if (notify != NO) {
+    [notificationCenter postNotificationName:OSEMediaVolumeDidAddNotification
+                                      object:self
+                                    userInfo:volumeInstance.properties];
+  }
+}
+
+- (void)_registerObjects
+{
+  [volumes removeAllObjects];
+  [drives removeAllObjects];
+
+  // Create OSEUDisksDrive instances
+  for (NSString *drivePath in OSEUDisksDrivesCache.allKeys) {
+    [self _registerDrive:drivePath andNotify:NO];
+  }
+
+  // Create OSEUDisksVolume instances and set to appropriate drive
+  for (NSString *blockDevicePath in udisksBlockDevicesCache.allKeys) {
+    [self _registerBlockDevice:blockDevicePath andNotify:NO];
+  }
+}
+
+// a{ oa{ sa{ sv } } }
+- (BOOL)_updateObjectsList
+{
+  NSArray *managedObjects = [self GetManagedObjects];
+  NSString *objectPath;
+
+  [managedObjects writeToFile:@"_ManagedObjects.result" atomically:NO];
+
+  [udisksBlockDevicesCache removeAllObjects];
+  [OSEUDisksDrivesCache removeAllObjects];
+
+  for (NSDictionary *object in managedObjects) {
+    objectPath = [object allKeys][0];  // ao{}
+    [self _parseObject:objectPath withProperties:object[objectPath]];
+  }
+
+  [self _registerObjects];
+
+  return YES;
+}
+
+// Returns volume dictionary which mounted at 'path'
+// 'path' is not necessary a mount point, it can be some path inside
+// mounted filesystem
+- (OSEUDisksVolume *)_mountedVolumeForPath:(NSString *)filesystemPath
+{
+  OSEUDisksVolume *volume = nil;
+  NSString *mp, *mp1;
+  NSString *mountPoint = nil;
+
+  // Find longest mount point for path
+  mp = @"";
+  for (OSEUDisksVolume *volume1 in [self mountedVolumes]) {
+    mountPoint = [volume1 mountPoints][0];
+    // NSLog(@"LongestMP(%@): process MP: %@", filesystemPath, mountPoint);
+    mp1 = NXTIntersectionPath(filesystemPath, mountPoint);
+    if ([mp1 isEqualToString:mountPoint] && ([mp1 length] >= [mp length])) {
+      ASSIGN(mp, mp1);
+      ASSIGN(volume, volume1);
     }
-  return value_str;
+  }
+
+  NSDebugLLog(@"udisks", @"Longest MP: %@ for path %@", [volume mountPoints], filesystemPath);
+
+  // if ([[volume mountPoints] isEqualToString:@"/"])
+  //   return nil;
+  // else
+  return [volume autorelease];
 }
 
-//--- Interesting functions
-
-// Interesting objects are: Drive, Block, Job
-static void
-monitor_on_object_added(GDBusObjectManager *manager,
-                        GDBusObject *object,
-                        gpointer user_data)
+// Returns list of OSEOSEUDisksVolume objects.
+// Each object represents mounted volume (fixed and removable).
+// If path == nil, returns list of all mounted diskVolumes in system.
+- (NSArray *)_mountedVolumesForDrive:(NSString *)driveObjectPath
 {
-  const gchar  *object_path;
-  UDisksObject *ud_object;
-  
-  object_path = g_dbus_object_get_object_path(object);
-  ud_object = udisks_client_get_object(udisks_client, object_path);
-  
-  [udisksAdaptor _addUDisksObject:ud_object andNotify:YES];
-  
-  // g_print("Object Added: %s\n", object_path);
-}
+  NSMutableArray *mountedVolumes;
+  OSEUDisksDrive *drive;
+  NSArray *driveVolumes;
 
-// Interesting objects are: Drive, Block, Job
-static void
-monitor_on_object_removed(GDBusObjectManager *manager,
-                           GDBusObject *object,
-                           gpointer user_data)
-{
-  const gchar *object_path;
-  
-  object_path = g_dbus_object_get_object_path(object);
-  
-  [udisksAdaptor _removeUDisksObjectWithPath:object_path];
+  if (driveObjectPath) {
+    drive = [drives objectForKey:driveObjectPath];
+    return [drive mountedVolumes];
+  }
 
-  // g_print("Object Removed: %s\n", g_dbus_object_get_object_path(object));
-}
-
-// Interesting objects(properties): Block(mount point)
-
-static void
-monitor_on_interface_proxy_properties_changed(GDBusObjectManagerClient *manager,
-                                              GDBusObjectProxy *object_proxy,
-                                              GDBusProxy *interface_proxy,
-                                              GVariant *changed_properties,
-                                              const gchar* const *invalidated_properties,
-                                              gpointer user_data)
-{
-  GVariantIter    *iter = NULL;
-  const gchar     *property_name = NULL;
-  GVariant        *value = NULL;
-  const gchar     *value_str = NULL;
-  const gchar     *object_path = NULL;
-  const gchar     *interface_name = NULL;
-  id<UDisksMedia> media;
-  NSArray         *removedProps;
-
-  object_path = g_dbus_object_get_object_path(G_DBUS_OBJECT(object_proxy));
-  interface_name = g_dbus_proxy_get_interface_name(interface_proxy);
-  
-  // g_print ("%s: %s: Properties Changed\n", object_path, interface_name);
-
-  g_variant_get(changed_properties, "a{sv}", &iter);
-  media = [udisksAdaptor _objectWithUDisksPath:object_path];
-  
-  while (g_variant_iter_next(iter, "{&sv}", &property_name, &value))
-    {
-      value_str = variant_to_string_with_indent(value,0);
-      // g_print("  %s: '%s'\n", property_name, value_str);
-      
-      [media setProperty:GSTR_2STR(property_name)
-                   value:GSTR_2STR(value_str)
-           interfaceName:GSTR_2STR(interface_name)];
-      
-      g_variant_unref(value);
+  mountedVolumes = [NSMutableArray new];
+  // e = [[drives allValues] objectEnumerator];
+  // while ((drive = [e nextObject]) != nil) {
+  for (OSEUDisksDrive *drive in [drives allValues]) {
+    driveVolumes = [drive mountedVolumes];
+    if (driveVolumes && [driveVolumes count] > 0) {
+      [mountedVolumes addObjectsFromArray:driveVolumes];
     }
+  }
 
-  // Remove invalidated properties
-  removedProps = GARR_2ARR(invalidated_properties);
-  if (removedProps)
-    {
-      [media removeProperties:removedProps
-                interfaceName:GSTR_2STR(interface_name)];
-    }
-}
-
-// 4FUTURE: Interesting objects: Job(object(Block), status, completion, progress)
-static void
-monitor_on_interface_proxy_signal(GDBusObjectManagerClient *manager,
-                                  GDBusObjectProxy         *object_proxy,
-                                  GDBusProxy               *interface_proxy,
-                                  const gchar              *sender_name,
-                                  const gchar              *signal_name,
-                                  GVariant                 *parameters,
-                                  gpointer                  user_data)
-{
-  gchar        *param_str;
-  UDisksJob    *job;
-  const gchar  *object_path;
-  UDisksObject *object;
-  const gchar *const *job_objects;
-
-  param_str = g_variant_print(parameters, TRUE);
-  // g_print ("Signal '%s:%s' on interface proxy %s:%s\n",
-  //          signal_name,
-  //          param_str,
-  //          g_dbus_proxy_get_interface_name(interface_proxy),
-  //          g_dbus_object_get_object_path(G_DBUS_OBJECT(object_proxy)));
-  g_free (param_str);
-
-  // Get object
-  object_path = g_dbus_object_get_object_path(G_DBUS_OBJECT(object_proxy));
-  object = udisks_client_get_object(udisks_client, object_path);
-
-  // Job signal
-  if ((job = udisks_object_peek_job(object)) != NULL)
-    {
-      job_objects = udisks_job_get_objects(job);
-      // g_print("Job status changed for %s:\n", object_path);
-      // g_print("\tObject path: %s\n\tOperation: %s\n\tObject: %s\n"
-      //         "\tSignal: %s\n\tParameters: %s\n",
-      //         object_path, udisks_job_get_operation(job), job_objects[0],
-      //         signal_name, g_variant_print(parameters, TRUE));
-
-      [udisksAdaptor _updateJob:object_path
-                        objects:job_objects
-                         signal:signal_name
-                     parameters:parameters];
-    }
-                                                      
-}
-
-//--- Less interesting functions
-
-static void
-monitor_on_interface_proxy_added(GDBusObjectManager *manager,
-                                  GDBusObject *object,
-                                  GDBusInterface *interface,
-                                  gpointer user_data)
-{
-  const gchar     *interface_name = NULL;
-  const gchar     *object_path = NULL;
-  id<UDisksMedia> media;
-
-  // g_print ("%s: Added interface %s\n",
-  //            g_dbus_object_get_object_path (object),
-  //            g_dbus_proxy_get_interface_name (G_DBUS_PROXY (interface)));
-
-  interface_name = g_dbus_proxy_get_interface_name(G_DBUS_PROXY(interface));
-  object_path = g_dbus_object_get_object_path (object);
-  
-  media = [udisksAdaptor _objectWithUDisksPath:object_path];
-  
-  [media setProperty:nil value:nil interfaceName:GSTR_2STR(interface_name)];
-  
-  // print_interface_properties (G_DBUS_PROXY (interface), 2);
-}
-
-static void
-monitor_on_interface_proxy_removed(GDBusObjectManager *manager,
-                                    GDBusObject        *object,
-                                    GDBusInterface     *interface,
-                                    gpointer            user_data)
-{
-  // g_print ("%s: Removed interface %s\n",
-  //            g_dbus_object_get_object_path (object),
-  //            g_dbus_proxy_get_interface_name (G_DBUS_PROXY (interface)));
-}
-
-
-// Timer selector
-- (void)_glibRunLoopIterate
-{
-  g_main_context_iteration(g_main_loop_get_context(glib_mainloop), FALSE);
-}
-
-- (void)_startEventsMonitor
-{
-  GDBusObjectManager *udisks_object_manager = NULL;
-
-  // Free with g_object_unref() when done with it.
-  udisks_object_manager = udisks_client_get_object_manager(udisks_client);
-
-  // Set events monitoring callbacks
-  g_signal_connect(udisks_object_manager,
-                   "object-added",
-                   G_CALLBACK(monitor_on_object_added),
-                   NULL);
-  g_signal_connect(udisks_object_manager,
-                   "object-removed",
-                   G_CALLBACK(monitor_on_object_removed),
-                   NULL);
-  g_signal_connect(udisks_object_manager,
-                   "interface-proxy-properties-changed",
-                   G_CALLBACK(monitor_on_interface_proxy_properties_changed),
-                   NULL);
-  g_signal_connect(udisks_object_manager,
-                   "interface-proxy-signal",
-                   G_CALLBACK(monitor_on_interface_proxy_signal),
-                   NULL);
-  
-  g_signal_connect(udisks_object_manager,
-                   "interface-added",
-                   G_CALLBACK(monitor_on_interface_proxy_added),
-                   NULL);
-  g_signal_connect(udisks_object_manager,
-                   "interface-removed",
-                   G_CALLBACK(monitor_on_interface_proxy_removed),
-                   NULL);
-
-  glib_mainloop = g_main_loop_new(NULL, TRUE);
-  
-  monitorTimer = [NSTimer
-                   scheduledTimerWithTimeInterval:1.0
-                                           target:self
-                                         selector:@selector(_glibRunLoopIterate)
-                                         userInfo:nil
-                                          repeats:YES];
-}
-
-- (void)_stopEventsMonitor
-{
-  [monitorTimer invalidate];
+  return mountedVolumes;
 }
 
 @end
 
+@implementation OSEUDisksAdaptor (Signals)
 
-//-----------------------------------------------------------------------
-//--- Volumes (filesystems) information
-//-----------------------------------------------------------------------
-
-@implementation OSEUDisksAdaptor (Info)
-
-//--- Convert UDisks objects into NSDictionary
-//    Utilities from 'udisksctl'
-static NSMutableDictionary *_propertiesForUDisksInterface(GDBusProxy *proxy)
+- (void)setSignalsMonitoring
 {
-  gchar **cached_properties;
-  guint n;
-  NSMutableDictionary *propertiesDict = [NSMutableDictionary new];
-
-  /* note: this is guaranteed to be sorted */
-  cached_properties = g_dbus_proxy_get_cached_property_names(proxy);
-
-  for (n = 0; cached_properties != NULL && cached_properties[n] != NULL; n++)
-    {
-      const gchar *property_name = cached_properties[n];
-      GVariant    *value;
-      gchar       *value_str;
-
-      value = g_dbus_proxy_get_cached_property(proxy, property_name);
-      value_str = variant_to_string_with_indent(value, 0);
-
-      [propertiesDict setObject:[NSString stringWithCString:value_str]
-                         forKey:[NSString stringWithCString:property_name]];
-
-      g_free(value_str);
-      g_variant_unref(value);
-    }
-  g_strfreev(cached_properties);
-
-  return propertiesDict;
-}
-
-// /org/freedesktop/UDisks2/drives/WDC_WD10JPVX...
-static NSMutableDictionary *_dictionaryFromUDisksObject(UDisksObject *object)
-{
-  GList               *interface_proxies = NULL;
-  GList               *l = NULL;
-  GDBusProxy          *iproxy = NULL;
-  const gchar         *interface_name = NULL;
-  NSMutableDictionary *objectDict;
-
-  // g_return_if_fail(G_IS_DBUS_OBJECT(object));
-
-  objectDict = [NSMutableDictionary new];
-  interface_proxies = g_dbus_object_get_interfaces(G_DBUS_OBJECT(object));
-
-  for (l = interface_proxies; l != NULL; l = l->next)
-    {
-      iproxy = G_DBUS_PROXY(l->data);
-      interface_name = g_dbus_proxy_get_interface_name(iproxy);
-      
-      [objectDict setObject:_propertiesForUDisksInterface(iproxy)
-                     forKey:GSTR_2STR(interface_name)];
-    }
+  [self.connection addSignalObserver:self
+                            selector:@selector(handlePropertiesChangedSignal:)
+                              signal:@"PropertiesChanged"
+                              object:self.objectPath
+                           interface:@"org.freedesktop.DBus.Properties"
+                        notification:OSEUDisksPropertiesDidChangeNotification];
   
-  g_list_foreach(interface_proxies, (GFunc)g_object_unref, NULL);
-  g_list_free(interface_proxies);
-
-  return objectDict;
-}
-
-//--- Access to properties of gathered objects (drives, volumes)
-- (NSString *)propertyWithName:(NSString *)property
-                     interface:(NSString *)interface
-                        object:(NSDictionary *)object
-{
-  NSDictionary *interfaceDict;
-  NSString     *value = nil;
-  NSArray      *arrayValue = nil;
+  [self.connection addSignalObserver:self
+                            selector:@selector(handleInterfacesAdeddSignal:)
+                              signal:@"InterfacesAdded"
+                              object:self.objectPath
+                           interface:@"org.freedesktop.DBus.ObjectManager"
+                        notification:OSEUDisksInterfacesDidAddNotification];
   
-  if ((interfaceDict = [object objectForKey:interface]))
-    {
-      if ((value = [interfaceDict objectForKey:property]))
-        {
-          if ((arrayValue = [value componentsSeparatedByString:@"\n"]))
-            {
-              if ([arrayValue count] > 1)
-                value = [arrayValue componentsJoinedByString:@","];
-              else
-                value = [arrayValue objectAtIndex:0];
-            }
-        }
-    }
-
-  return value;
+  [self.connection addSignalObserver:self
+                            selector:@selector(handleInterfacesRemovedSignal:)
+                              signal:@"InterfacesRemoved"
+                              object:self.objectPath
+                           interface:@"org.freedesktop.DBus.ObjectManager"
+                        notification:OSEUDisksInterfacesDidRemoveNotification];
 }
 
-- (NSString *)jobProperty:(NSString *)property
-                   forJob:(NSDictionary *)job
+- (void)handlePropertiesChangedSignal:(NSNotification *)aNotif
 {
-  return [self propertyWithName:property
-                      interface:@"org.freedesktop.UDisks2.Job"
-                         object:job];
+  NSLog(@"OSEUDisksAdaptor \e[1mPropertiesChanged\e[0m: %@", aNotif.userInfo[@"Message"]);
 }
 
-// TODO: join with propertyWithName...?
-- (id)objectForJob:(NSDictionary *)job
+- (void)handleInterfacesAdeddSignal:(NSNotification *)aNotif
 {
-  NSString *objectPath = [self jobProperty:@"Objects" forJob:job];
-  id theObject;
+  NSLog(@"OSEUDisksAdaptor \e[1mInterfacesAdded\e[0m: %@", aNotif.userInfo[@"Message"]);
 
-  if ([objectPath rangeOfString:@"["].location == 0)
-    {
-      objectPath = [objectPath stringByReplacingOccurrencesOfString:@"[" withString:@""];
-      objectPath = [objectPath stringByReplacingOccurrencesOfString:@"]" withString:@""];
-      objectPath = [objectPath stringByReplacingOccurrencesOfString:@"'" withString:@""];
-    }
+  NSArray *message = aNotif.userInfo[@"Message"];
+  NSString *objectPath = nil;
+  NSArray *objectProperties = nil;
 
-  return [self _objectWithUDisksPath:[objectPath cString]];
-}
+  if (message && message.count > 1) {
+    objectPath = message[0];
+    objectProperties = message[1];
+  } else {
+    NSLog(@"OSEUDisksAdaptor error: message in InterfaceAdded notification is broken.");
+    return;
+  }
 
-//--- Add/Remove UDisks objects
-
-- (id)_objectWithUDisksPath:(const gchar *)object_path
-{
-  NSString *objectPath = GSTR_2STR(object_path);
-  NSArray  *pathComponents = [objectPath pathComponents];
-  NSString *objectType;
-
-  objectType = [pathComponents objectAtIndex:[pathComponents count] - 2];
+  [self _parseObject:objectPath withProperties:objectProperties];
   
-  if ([objectType isEqualToString:@"drives"])
-    {
-      return [drives objectForKey:objectPath];
-    }
-  else if ([objectType isEqualToString:@"block_devices"])
-    {
-      return [volumes objectForKey:objectPath];
-    }
-  else if ([objectType isEqualToString:@"jobs"])
-    {
-      return [jobsCache objectForKey:objectPath];
-    }
-  
-  return nil;
+  switch ([self _objectTypeForPath:objectPath]) {
+    case OSEOSEUDisksDriveObject:
+      [self _registerDrive:objectPath andNotify:YES];
+      [drives[objectPath] _dumpProperties];
+      break;
+    case OSEUDisksBlockObject: {
+      OSEUDisksVolume *volume = [volumes objectForKey:objectPath];
+      if (volume == nil) {
+        [self _registerBlockDevice:objectPath andNotify:YES];
+        [volumes[objectPath] _dumpProperties];
+      } else {
+        // OSEUDisksAdaptor InterfacesAdded: (
+        // "/org/freedesktop/UDisks2/block_devices/sr0", <--- message[0]
+        //   ({                                          <--- message[1]
+        //     "org.freedesktop.UDisks2.Filesystem" = (
+        //       { MountPoints = (); },
+        //       { Size = 0; }
+        //     );
+        //   })
+        // )
+        // 1. Normalize 'objectProperties'
+        // 2. [volume setProperty:@"MountPoints" value:(NSString *)
+        // interfaceName:@"org.fredesktop.UDisks2.Filesystem"]
+        NSMutableDictionary *properties = [self _parseBlockDeviceProperties:message[1]];
+        [[volume properties] addEntriesFromDictionary:properties];
+        [volume _dumpProperties];
+        [properties release];
+      }
+      [[volumes objectForKey:objectPath] mount:YES];
+    } break;
+    case OSEUDisksJobObject: {
+      // TODO
+      // OSEUDisksAdaptor InterfacesAdded: (
+      // "/org/freedesktop/UDisks2/jobs/1",    <--- message[0]
+      // ({                                    <--- message[1]
+      //    "org.freedesktop.UDisks2.Job" = (
+      //      {Operation = "filesystem-unmount"; },
+      //      {Progress = 0; },
+      //      {ProgressValid = 0; },
+      //      {Bytes = 0; },
+      //      {Rate = 0; },
+      //      {StartTime = 1736953604254703; },
+      //      {ExpectedEndTime = 0; },
+      //      {Objects = ("/org/freedesktop/UDisks2/block_devices/sr0"); },
+      //      {StartedByUID = 0; },
+      //      {Cancelable = 1; }
+      //   );
+      // })
+      // )
+      NSString *objectPath = message[0];
+      NSArray *jobProperties = message[1];
+      NSMutableDictionary *properties =
+          [self _parsePropertiesSection:jobProperties.firstObject[JOB_INTERFACE]];
+      [jobsCache setObject:properties forKey:objectPath];
+    } break;
+    default:
+      NSLog(@"OSEUDisksAdaptor Warning: trying to remove unknown object type with path %@", objectPath);
+  }
 }
 
-- (void)_addUDisksObject:(UDisksObject *)object
-               andNotify:(BOOL)notify
+- (void)handleInterfacesRemovedSignal:(NSNotification *)aNotif
 {
-  NSString       *objectPath;
-  NSArray        *pathComponents;
-  NSString       *objectType;
-  NSDictionary   *driveProps, *volumeProps, *job;
-  OSEUDisksDrive  *drive;
+  NSLog(@"OSEUDisksAdaptor \e[1mInterfacesRemoved\e[0m: %@", aNotif.userInfo[@"Message"]);
+  NSArray *message = aNotif.userInfo[@"Message"];
+  NSString *objectPath;
+
+  if (message.count == 0) {
+    NSLog(@"OSEUDisksAdaptor InterfacesRemoved warning: no object path specified in message.");
+    return;
+  } else {
+    objectPath = message.firstObject;
+  }
+
+  if (message.count == 1) {
+    [self _removeObject:objectPath andNotify:YES];
+  } else if (message.count > 1) {
+    id<UDisksObject> object = nil;
+    // TODO: OSEUDisksAdaptor InterfacesRemoved:
+    // ("/org/freedesktop/UDisks2/block_devices/sr0", ("org.freedesktop.UDisks2.Filesystem"))
+    switch ([self _objectTypeForPath:objectPath]) {
+      case OSEUDisksBlockObject: {
+        object = [volumes objectForKey:objectPath];
+      } break;
+      case OSEOSEUDisksDriveObject: {
+        object = [drives objectForKey:objectPath];
+      } break;
+      case OSEUDisksJobObject: {
+        [jobsCache removeObjectForKey:objectPath];
+      } break;
+      default:
+        NSLog(@"OSEUDisksAdaptor InterfacesRemoved warning: unknown object type was removed, skipping.");
+        break;
+    }
+    if (object != nil) {
+      for (NSString *interface in message[1]) {
+        [[object properties] removeObjectForKey:interface];
+      }
+      if (object.properties.allKeys.count == 0) {
+        [self _removeObject:objectPath andNotify:YES];
+      }
+      [object _dumpProperties];
+    }
+  }
+}
+
+@end
+
+@implementation OSEUDisksAdaptor
+
+//-------------------------------------------------------------------------------
+#pragma mark - Init
+//-------------------------------------------------------------------------------
+- (id)init
+{
+  [super init];
+
+  self.objectPath = @"/org/freedesktop/UDisks2";
+  self.serviceName = @"org.freedesktop.UDisks2";
+
+  OSEUDisksDrivesCache = [NSMutableDictionary new];
+  udisksBlockDevicesCache = [NSMutableDictionary new];
+
+  drives = [NSMutableDictionary new];
+  volumes = [NSMutableDictionary new];
+  jobsCache = [NSMutableDictionary new];
+
+  if ([self _updateObjectsList] != NO) {
+    [OSEUDisksDrivesCache writeToFile:@"_UDisks.drives.result" atomically:YES];
+    [udisksBlockDevicesCache writeToFile:@"_UDisks.block_devices.result" atomically:YES];
+  }
+
+  notificationCenter = [NSNotificationCenter defaultCenter];
+  [self setSignalsMonitoring];
+
+  return self;
+}
+
+- (void)dealloc
+{
+  NSDebugLLog(@"OSEUDisksAdaptor", @"OSEUDisksAdaptor: dealloc");
+
+  [udisksBlockDevicesCache release];
+  [OSEUDisksDrivesCache release];
+
+  [volumes release];
+  [drives release];
+
+  [super dealloc];
+}
+
+//-------------------------------------------------------------------------------
+#pragma mark - Main implementation
+//-------------------------------------------------------------------------------
+
+// It's for 'disktool'
+// TODO: remove by fixing 'disktool'
+- (NSDictionary *)availableDrives
+{
+  return drives;
+}
+
+// Used by OSEOSEUDisksDrive to collect it's diskVolumes.
+// That's why we iterate registered diskVolumes.
+- (NSDictionary *)availableVolumesForDrive:(NSString *)driveObjectPath
+{
+  NSArray *volumePaths = [volumes allKeys];
   OSEUDisksVolume *volume;
-      
-  objectPath = GSTR_2STR(g_dbus_object_get_object_path(G_DBUS_OBJECT(object)));
-  pathComponents = [objectPath pathComponents];
-  objectType = [pathComponents objectAtIndex:[pathComponents count] - 2];
+  NSMutableDictionary *driveVolumes = [NSMutableDictionary new];
 
-  if ([objectType isEqualToString:@"drives"])
-    {
-      driveProps = _dictionaryFromUDisksObject(object);
-      // Missed volumes added here
-      drive = [[OSEUDisksDrive alloc] initWithProperties:driveProps
-                                             objectPath:objectPath
-                                                adaptor:self];
-      [drives setObject:drive forKey:objectPath];
-      // [drives writeToFile:@"Library/Workspace/Drives.plist" atomically:YES];
-
-      if (notify)
-        {
-          [notificationCenter postNotificationName:OSEMediaDriveDidAddNotification
-                                            object:self
-                                          userInfo:driveProps];
-        }
+  for (NSString *path in volumePaths) {
+    volume = [volumes objectForKey:path];
+    if ([[volume driveObjectPath] isEqualToString:driveObjectPath]) {
+      [driveVolumes setObject:volume forKey:path];
     }
-  else if ([objectType isEqualToString:@"block_devices"])
-    {
-      volumeProps = _dictionaryFromUDisksObject(object);
-      volume = [[OSEUDisksVolume alloc] initWithProperties:volumeProps
-                                               objectPath:objectPath
-                                                  adaptor:self];
-      [volumes setObject:volume forKey:objectPath];
-      // [volumes writeToFile:@"Library/Workspace/Volumes.plist" atomically:YES];
+  }
 
-      // Connect the dots. If drive is not yet registered, volume will be added
-      // on drive creation (see 'if' above)
-      
-      if (notify)
-        {
-          [notificationCenter postNotificationName:OSEMediaVolumeDidAddNotification
-                                            object:self
-                                          userInfo:volumeProps];
-          if ([volume isFilesystem])
-            {
-              // Emits OSEMediaVolumeDidMountNotification notification
-              // We are called by event of inserted device not during initial
-              // registraion of objects.
-              [volume mount:NO];
-            }
-        }
-    }
-  // else if ([objectType isEqualToString:@"jobs"])
-  //   {
-  //     job = _dictionaryFromUDisksObject(object);
-  //     [jobsCache setObject:job forKey:objectPath];
-  //     [jobsCache writeToFile:@"Library/Workspace/JobsCache.plist" atomically:YES];
-      
-  //     if (notify)
-  //       {
-  //         NSString *op = [self jobProperty:@"Operation" forJob:job];
-  //         NSString *operation = nil, *message, *object;
-
-  //         if ([op isEqualToString:@"filesystem-mount"])
-  //           {
-  //             operation = @"Mount";
-  //             object = [(OSEUDisksVolume *)[self objectForJob:job] UNIXDevice];
-  //           }
-  //         else if ([op isEqualToString:@"filesystem-unmount"])
-  //           {
-  //             operation = @"Unmount";
-  //             object = [(OSEUDisksVolume *)[self objectForJob:job] mountPoints];
-  //           }
-  //         else if ([op isEqualToString:@"drive-eject"])
-  //           {
-  //             operation = @"Eject";
-  //             object = [(OSEUDisksDrive *)[self objectForJob:job] humanReadableName];
-  //           }
-
-  //         if (operation)
-  //           {
-  //             message = [NSString stringWithFormat:@"%@ing %@...", operation, object];
-  //             [self operationWithName:operation
-  //                             jobPath:objectPath
-  //                              failed:NO
-  //                              status:@"Started"
-  //                               title:operation
-  //                             message:message];
-  //           }
-  //       }
-  //  }
+  return driveVolumes;
 }
 
-// On the event of unsafely disconnected removable drive UDisks make cleanup
-// of all objects related to disconnected drive. During cleanup unmount
-// notification is not sent. 
-// Unsafe detach action chain:
-//   * volumes removed - drive added to drivesToCleanup list;
-//   * drive removed - if drive in drivesToClean send message to application;
-//                     drive deleted from drivesToCleanup list.
-- (void)_removeUDisksObjectWithPath:(const gchar *)object_path
+- (id)objectWithUDisksPath:(NSString *)objectPath
 {
-  NSString            *objectPath = GSTR_2STR(object_path);
-  NSArray             *pathComponents = [objectPath pathComponents];
-  NSString            *objectType;
-  OSEUDisksDrive       *drive;
-  OSEUDisksVolume      *volume;
-  NSDictionary        *info;
-  NSString            *message = nil;
+  id object = nil;
+
+  switch ([self _objectTypeForPath:objectPath]) {
+    case OSEOSEUDisksDriveObject:
+      object = [drives objectForKey:objectPath];
+      break;
+    case OSEUDisksBlockObject: 
+      object = [volumes objectForKey:objectPath];
+      break;
+    case OSEUDisksJobObject:
+      object = [jobsCache objectForKey:objectPath];
+      break;
+    default:
+      NSLog(@"OSEUDisksAdaptor objectWithUDisksPath: unknow object for object path %@", objectPath);
+  }
   
-  objectType = [pathComponents objectAtIndex:[pathComponents count] - 2];
-  
-  if ([objectType isEqualToString:@"drives"])
-    {
-      drive = [drives objectForKey:objectPath];
-      
-      if ([drivesToCleanup containsObject:objectPath])
-        {
-          message = [NSString
-                          stringWithFormat:
-                        @"Disk '%@' with mounted volumes was disconnected.\n"
-                      "Eject disk before disconnecting to avoid data loss.",
-                      [drive humanReadableName]];
-          
-          [self operationWithName:@"Detach"
-                          object:drive
-                           failed:YES
-                           status:@"Completed"
-                            title:@"Unsafe media detach"
-                          message:message];
-          [drivesToCleanup removeObject:objectPath];
-        }
-
-      if (message)
-        {
-          info = [NSDictionary dictionaryWithObjectsAndKeys:
-                                 @"Info",       @"MessageType",
-                               @"Eject Disk", @"MessageTitle",
-                               message,       @"Message", nil];
-          // OSEMediaDriveDidRemoveNotification notification
-          [notificationCenter postNotificationName:OSEMediaDriveDidRemoveNotification
-                                            object:self
-                                          userInfo:info];
-        }
-
-      [drives removeObjectForKey:objectPath];
-      // [drives writeToFile:@"Library/Workspace/Drives.plist" atomically:YES];
-      return;
-    }
-  else if ([objectType isEqualToString:@"block_devices"])
-    {
-      volume = [volumes objectForKey:objectPath];
-      
-      if ([volume isMounted])
-        {
-          [drivesToCleanup addObject:[[volume drive] objectPath]];
-        }
-      
-      // OSEMediaVolumeDidRemoveNotification notification
-      [notificationCenter postNotificationName:OSEMediaVolumeDidRemoveNotification
-                                        object:self
-                                      userInfo:[volume properties]];
-
-      [[volume drive] removeVolumeWithKey:objectPath];
-      [volumes removeObjectForKey:objectPath];
-      // [volumes writeToFile:@"Library/Workspace/Volumes.plist" atomically:YES];
-      return;
-    }
-  else if ([objectType isEqualToString:@"jobs"])
-    {
-      [jobsCache removeObjectForKey:objectPath];
-    }
+  return object;
 }
 
-- (void)_registerObjects:(UDisksClient *)client
+- (OSEUDisksVolume *)mountedVolumeForPath:(NSString *)filesystemPath
 {
-  GList *l;
-  GList *objects;
+  OSEUDisksVolume *volume = nil;
+  NSString *commonPath = nil;
 
-  // Clear cache first
-  [drives removeAllObjects];
-  [volumes removeAllObjects];
-  
-  // Get list of UDisksObject (udisks object manager holds list of dbus objects
-  // of this type)
-  objects = g_dbus_object_manager_get_objects(udisks_client_get_object_manager(udisks_client));
-  for (l = objects; l != NULL; l = l->next)
-    {
-      [self _addUDisksObject:UDISKS_OBJECT(l->data) andNotify:NO];
+  // Find longest mount point for path
+  for (OSEUDisksVolume *vol in [self mountedVolumes]) {
+    for (NSString *mp in [vol mountPoints]) {
+      commonPath = NXTIntersectionPath(filesystemPath, mp);
+      if ([commonPath isEqualToString:mp] && ([commonPath length] >= [mp length])) {
+        volume = vol;
+      }
     }
-  
-  g_list_foreach(objects, (GFunc)g_object_unref, NULL);
-  g_list_free(objects);
+  }
+
+  NSDebugLLog(@"udisks", @"Longest MP: %@ for path %@", [volume mountPoints], filesystemPath);
+
+  return volume;
 }
 
-//--- Signals // TODO
 - (void)operationWithName:(NSString *)name
                    object:(id)object
                    failed:(BOOL)failed
@@ -696,490 +627,98 @@ static NSMutableDictionary *_dictionaryFromUDisksObject(UDisksObject *object)
   [info setObject:name forKey:@"Operation"];
   [info setObject:title forKey:@"Title"];
   [info setObject:message forKey:@"Message"];
-  if ([name isEqualToString:@"Mount"] || [name isEqualToString:@"Unmount"])
-    {
+  if ([name isEqualToString:@"Mount"] || [name isEqualToString:@"Unmount"]) {
+    [info setObject:[object UNIXDevice] forKey:@"UNIXDevice"];
+  } else if ([name isEqualToString:@"Eject"]) {
+    [info setObject:[object humanReadableName] forKey:@"UNIXDevice"];
+  }
+
+  if (failed) {
+    [info setObject:@"false" forKey:@"Success"];
+  } else {
+    [info setObject:@"true" forKey:@"Success"];
+  }
+
+  if ([status isEqualToString:@"Started"]) {
+    [notificationCenter postNotificationName:OSEMediaOperationDidStartNotification object:self userInfo:info];
+  } else {
+    // "Completed" - operation was started by framework methods.
+    // NXVolume* and OSEMediaOperation* notifications will be sent.
+    // "Occured" - operation was performed without framework methods (outside)
+    // of application. Only NXVolume* notification will be sent.
+    if ([name isEqualToString:@"Mount"] || [name isEqualToString:@"Unmount"]) {
       [info setObject:[object UNIXDevice] forKey:@"UNIXDevice"];
-    }
-  else if ([name isEqualToString:@"Eject"])
-    {
-      [info setObject:[object humanReadableName] forKey:@"UNIXDevice"];
-    }
 
-  if (failed)
-    {
-      [info setObject:@"false" forKey:@"Success"];
-    }
-  else
-    {
-      [info setObject:@"true" forKey:@"Success"];
-    }
+      if ([name isEqualToString:@"Mount"] && !failed) {
+        [info setObject:[object mountPoints] forKey:@"MountPoint"];
+        [notificationCenter postNotificationName:OSEMediaVolumeDidMountNotification object:self userInfo:info];
+      } else if ([name isEqualToString:@"Unmount"] && !failed) {
+        NSString *mp = [object mountPoints][0];
 
-  if ([status isEqualToString:@"Started"])
-    {
-      [notificationCenter postNotificationName:OSEMediaOperationDidStartNotification
-                                        object:self
-                                      userInfo:info];
-    }
-  else 
-    {
-      // "Completed" - operation was started by framework methods.
-      // NXVolume* and OSEMediaOperation* notifications will be sent.
-      // "Occured" - operation was performed without framework methods (outside)
-      // of application. Only NXVolume* notification will be sent.
-      if ([name isEqualToString:@"Mount"] || [name isEqualToString:@"Unmount"])
-        {
-          [info setObject:[object UNIXDevice] forKey:@"UNIXDevice"];
-          
-          if ([name isEqualToString:@"Mount"] && !failed)
-            {
-              [info setObject:[object mountPoints] forKey:@"MountPoint"];
-              [notificationCenter postNotificationName:OSEMediaVolumeDidMountNotification
-                                                object:self
-                                              userInfo:info];
-            }
-          else if ([name isEqualToString:@"Unmount"] && !failed)
-            {
-              NSString *mp = [object mountPoints];
-
-              // If "MountPoint" property of NX*Volume already updated
-              // get value saved into "OldMountPoint" property
-              if (!mp || [mp isEqualToString:@""])
-                {
-                  mp = [object propertyForKey:@"OldMountPoint"
-                                    interface:FS_INTERFACE];
-                }
-              [info setObject:mp forKey:@"MountPoint"];
-              [notificationCenter postNotificationName:OSEMediaVolumeDidUnmountNotification
-                                                object:self
-                                              userInfo:info];
-            }
+        // If "MountPoint" property of NX*Volume already updated
+        // get value saved into "OldMountPoint" property
+        if (!mp || [mp isEqualToString:@""]) {
+          mp = [object propertyForKey:@"OldMountPoint" interface:FS_INTERFACE];
         }
-
-      if ([status isEqualToString:@"Completed"])
-        {
-          [notificationCenter postNotificationName:OSEMediaOperationDidEndNotification
-                                            object:self
-                                          userInfo:info];
-        }
+        [info setObject:mp forKey:@"MountPoint"];
+        [notificationCenter postNotificationName:OSEMediaVolumeDidUnmountNotification object:self userInfo:info];
+      }
     }
+
+    if ([status isEqualToString:@"Completed"]) {
+      [notificationCenter postNotificationName:OSEMediaOperationDidEndNotification object:self userInfo:info];
+    }
+  }
 }
 
-// It's always called by monitor_on_interface_proxy_signal().
-- (void)_updateJob:(const gchar *)job_path
-           objects:(const gchar *const *)job_objects
-            signal:(const gchar *)signal_name
-        parameters:(GVariant *)parameters
-{
-  // NSDictionary    *job = [self _objectWithUDisksPath:job_path];
-  // NSString        *operation = [self jobProperty:@"Operation" forJob:job];
-  // NSString        *objectName = nil;
-  // NSString        *op = nil;
-  // NSMutableString *message = nil;
-  // NSString        *title = nil;
-  // BOOL            isOperationFailed;
-
-  // NSLog(@"_updateJob:objects:%@", GARR_2ARR(job_objects));
-
-  // // TODO: Convert from g* to ObjC types needs review across all OSEUDisks* classes.
-  // NSString        *params;
-  // NSArray         *paramsArray;
-  // // Normalize parameters list before NSString will be converted to NSArray.
-  // params = [NSString stringWithCString:g_variant_print(parameters, TRUE)];
-  // params = [params stringByReplacingOccurrencesOfString:@"\'" withString:@"\\\""];
-  // params = [params stringByReplacingOccurrencesOfString:@"`" withString:@"\\\""];
-  // params = [params stringByReplacingOccurrencesOfString:@"\\\"" withString:@""];
-  // NSDebugLLog(@"udisks", @"Signal Parameters NSString: %@", params);
-  
-  // paramsArray = [params propertyList];
-  // NSDebugLLog(@"udisks", @"Signal Parameters NSArray: %@", paramsArray);
-
-  // // Status
-  // isOperationFailed = [[paramsArray objectAtIndex:0] isEqualToString:@"false"];
-  
-  // // Operation, JobPath(?)
-  // if ([operation isEqualToString:@"filesystem-unmount"])
-  //   {
-  //     objectName = [(OSEUDisksVolume *)[self objectForJob:job] UNIXDevice];
-  //     op = @"Unmount";
-  //   }
-  // else if ([operation isEqualToString:@"filesystem-mount"])
-  //   {
-  //     objectName = [(OSEUDisksVolume *)[self objectForJob:job] UNIXDevice];
-  //     op = @"Mount";
-  //   }
-  // // 'Eject' is a special case: contains unmounting all volumes of drive,
-  // // eject ('drive-eject') and power off. Thus notifications about start and finish
-  // // of eject process are sent by OSEUDisksDrive object.
-  // // Except the failed eject process.
-  // else if ([operation isEqualToString:@"drive-eject"] && isOperationFailed)
-  //   {
-  //     objectName = [(OSEUDisksDrive *)[self objectForJob:job] humanReadableName];
-  //     op = @"Eject";
-  //   }
-      
-  // if (!strcmp(signal_name, "Completed"))
-  //   {
-  //     // Message and Title
-  //     if (isOperationFailed)
-  //       {
-  //         //--- "Message"
-  //         if ([paramsArray count] > 1)
-  //           {
-  //             message = [[paramsArray objectAtIndex:1] mutableCopy];
-  //             NSUInteger iters = ([message length]/80) - 1, i;
-
-  //             for (i = 1; i <= iters; i++)
-  //               {
-  //                 [message insertString:@"\n" atIndex:80*i];
-  //               }
-  //           }
-  //         title = [NSString stringWithFormat:@"%@ Error", op];
-  //       }
-  //     else
-  //       {
-  //         message = [NSString stringWithFormat:@"%@ing of '%@' finished",
-  //                             op, objectName];
-  //         title = [NSString stringWithFormat:@"%@ Finished", op];
-  //       }
-
-  //     // Send notification
-  //     if (op)
-  //       {
-  //         [self operationWithName:op
-  //                         jobPath:[NSString stringWithCString:job_path]
-  //                          failed:isOperationFailed
-  //                          status:@"Completed"
-  //                           title:title
-  //                         message:message];
-  //       }
-  //   }
-  // else if (!strcmp(signal_name, "Started"))
-  //   {
-  //     NSLog(@"Job %s was started!", job_path);
-      
-  //     message = [NSString stringWithFormat:@"%@ing %@", op, objectName];
-      
-  //     if (op)
-  //       {
-  //         [self operationWithName:op
-  //                         jobPath:[NSString stringWithCString:job_path]
-  //                          failed:isOperationFailed
-  //                          status:@"Started"
-  //                           title:op
-  //                         message:message];
-  //       }
-  //   }
-}
-
-- (NSString *)descriptionForError:(GError *)error
-{
-  // UDISKS_ERROR_DEVICE_BUSY: Attempting to unmount a device that is busy.
-  if (g_error_matches(error, UDISKS_ERROR, UDISKS_ERROR_DEVICE_BUSY))
-    {
-      return @"Failed to unmount a media that is busy by active process.";
-    }
-   // UDISKS_ERROR_FAILED: The operation failed.
-  else if (g_error_matches(error, UDISKS_ERROR, UDISKS_ERROR_FAILED))
-    {
-      return @"The operation failed.";
-    }
-   // UDISKS_ERROR_CANCELLED: The operation was cancelled.
-   // UDISKS_ERROR_ALREADY_CANCELLED: The operation has already been cancelled.
-  else if (g_error_matches(error, UDISKS_ERROR, UDISKS_ERROR_CANCELLED) ||
-           g_error_matches(error, UDISKS_ERROR, UDISKS_ERROR_ALREADY_CANCELLED))
-    {
-      return @"The operation was canceled.";
-    }
-   // UDISKS_ERROR_TIMED_OUT: The operation timed out.
-  else if (g_error_matches(error, UDISKS_ERROR, UDISKS_ERROR_TIMED_OUT))
-    {
-      return @"The operation timed out.";
-    }
-  // UDISKS_ERROR_NOT_AUTHORIZED: Not authorized to perform the requested operation.
-  // UDISKS_ERROR_NOT_AUTHORIZED_CAN_OBTAIN: Like %UDISKS_ERROR_NOT_AUTHORIZED
-  // but authorization can be obtained through e.g. authentication.
-  // UDISKS_ERROR_NOT_AUTHORIZED_DISMISSED: Like %UDISKS_ERROR_NOT_AUTHORIZED but an
-  // authentication was shown and the user dimissed it.
-  else if (g_error_matches(error, UDISKS_ERROR,UDISKS_ERROR_NOT_AUTHORIZED) ||
-           g_error_matches(error, UDISKS_ERROR, UDISKS_ERROR_NOT_AUTHORIZED_CAN_OBTAIN) ||
-           g_error_matches(error, UDISKS_ERROR, UDISKS_ERROR_NOT_AUTHORIZED_DISMISSED))
-    {
-      return @"You do not have permission to perform the requested operation.";
-    }
-  // UDISKS_ERROR_ALREADY_MOUNTED: The device is already mounted.
-  else if (g_error_matches(error, UDISKS_ERROR, UDISKS_ERROR_ALREADY_MOUNTED))
-    {
-      return @"The device is already mounted.";
-    }
-  // UDISKS_ERROR_NOT_MOUNTED: The device is not mounted.
-  else if (g_error_matches(error, UDISKS_ERROR, UDISKS_ERROR_NOT_MOUNTED))
-    {
-      return @"The device is not mounted.";
-    }
-  // UDISKS_ERROR_OPTION_NOT_PERMITTED: Not permitted to use the requested option.
-  else if (g_error_matches(error, UDISKS_ERROR, UDISKS_ERROR_OPTION_NOT_PERMITTED))
-    {
-      return @"You do not have permission to used requested option.";
-    }
-  // UDISKS_ERROR_MOUNTED_BY_OTHER_USER: The device is mounted by another user.
-  else if (g_error_matches(error, UDISKS_ERROR, UDISKS_ERROR_MOUNTED_BY_OTHER_USER))
-    {
-      return @"The media is mounted by another user.";
-    }
-  // UDISKS_ERROR_ALREADY_UNMOUNTING: The device is already unmounting.
-  else if (g_error_matches(error, UDISKS_ERROR, UDISKS_ERROR_ALREADY_UNMOUNTING))
-    {
-      return @"The media unmounting is already in progress.";
-    }
-  // UDISKS_ERROR_NOT_SUPPORTED: The operation is not supported due to missing
-  // driver/tool support.
-  else if (g_error_matches(error, UDISKS_ERROR, UDISKS_ERROR_NOT_SUPPORTED))
-    {
-      return @"The operation is not supported due to missing driver/tool support.";
-    }
-  // UDISKS_ERROR_WOULD_WAKEUP: The operation would wake up a disk that is
-  // in a deep-sleep state.
-  else if (g_error_matches(error, UDISKS_ERROR, UDISKS_ERROR_NOT_SUPPORTED))
-    {
-      return @"The operation is not supported due to missing driver/tool support.";
-    }
-
-  return nil;
-}
-
-@end
-
-//-----------------------------------------------------------------------
-//--- Actions
-//-----------------------------------------------------------------------
-
-@implementation OSEUDisksAdaptor
-
-- (id)init
-{
-  GError *udisks_error = NULL;
-  
-  udisksAdaptor = self = [super init];
-  
-  notificationCenter = [NSNotificationCenter defaultCenter];
-  
-  udisks_client = udisks_client_new_sync(NULL, &udisks_error);
-
-  jobsCache = [[NSMutableDictionary alloc] init];
-
-  drives = [[NSMutableDictionary alloc] init];
-  volumes = [[NSMutableDictionary alloc] init];
- 
-  drivesToCleanup = [[NSMutableArray alloc] init];
-  monitorTimer = nil;
-
-  // Fill drives and volumes arrays with objects
-  [self _registerObjects:udisks_client];
-
-  [self _startEventsMonitor];
-
-  return self;
-}
-
-- (void)dealloc
-{
-  NSDebugLLog(@"udisks", @"OSEUDisksAdaptor: dealloc");
-  if ([monitorTimer isValid])
-    {
-      [self _stopEventsMonitor];
-    }
-  
-  // [jobsCache release];
-  
-  // [drives release];
-  // [volumes release];
-  
-  // [drivesToCleanup release];
-  
-  g_object_unref(udisks_client);
-
-  [super dealloc];
-}
-
-- (UDisksClient *)udisksClient
-{
-  return udisks_client;
-}
-
-//--- Info
-
-// Returns list of OSEUDisksVolume objects.
-// Each object represents mounted volume (fixed and removable).
-// If path == nil, returns list of all mounted volumes in system.
-- (NSArray *)mountedVolumesForDrive:(NSString *)driveObjectPath
-{
-  NSMutableArray *mountedVolumes;
-  NSEnumerator   *e;
-  OSEUDisksDrive  *drive;
-  NSArray        *driveVolumes;
-
-  if (driveObjectPath)
-    {
-      drive = [drives objectForKey:driveObjectPath];
-      return [drive mountedVolumes];
-    }
-  
-  mountedVolumes = [NSMutableArray new];
-  e = [[drives allValues] objectEnumerator];
-  while ((drive = [e nextObject]) != nil)
-    {
-      driveVolumes = [drive mountedVolumes];
-      if (driveVolumes && [driveVolumes count] > 0)
-        {
-          [mountedVolumes addObjectsFromArray:driveVolumes];
-        }
-    }
-    
-  return mountedVolumes;
-}
-
-// Returns list of all mounted volumes.
-// Scan through local volumes cache to get loop volumes (volumes without drive)
+//-------------------------------------------------------------------------------
+#pragma mark - MediaManager protocol
+//-------------------------------------------------------------------------------
+// Returns list of all mounted diskVolumes.
+// Scan through local diskVolumes cache to get loop diskVolumes (diskVolumes without drive)
 - (NSArray *)mountedVolumes
 {
   NSMutableArray *mountedVolumes = [NSMutableArray new];
 
-  for (OSEUDisksVolume *volume in [volumes allValues])
-    {
-      if ([volume isMounted])
-        {
-          [mountedVolumes addObject:volume];
-        }
+  for (OSEUDisksVolume *volume in [volumes allValues]) {
+    if ([volume isMounted]) {
+      [mountedVolumes addObject:volume];
     }
+  }
 
   return mountedVolumes;
-}
-
-// Returns list of pathnames to mount points of already mounted volumes.
-   // NSWorkspace
-- (NSArray *)mountedRemovableMedia
-{
-  NSArray        *mountedVolumes = [self mountedVolumes];
-  NSEnumerator   *de;
-  OSEUDisksVolume *volume;
-  NSMutableArray *mountPaths = [NSMutableArray new];
-
-  de = [mountedVolumes objectEnumerator];
-  while ((volume = [de nextObject]) != nil)
-    {
-      NSDebugLLog(@"udisks", @"Adaptor: mountedRemovableMedia check: %@ (%@)",
-                  [volume mountPoints],
-                  [[[[volume drive] properties] objectForKey:@"org.freedesktop.UDisks2.Drive"] objectForKey:@"Id"]);
-      
-      if ([volume isFilesystem] &&
-          ([[volume drive] isRemovable] ||
-           [[volume drive] isMediaRemovable]))
-        {
-          [mountPaths addObject:[volume mountPoints]];
-        }
-    }
-
-  NSDebugLLog(@"udisks", @"Adaptor: mountedRemovableMedia: %@",
-              mountPaths);
-
-  return mountPaths;
-}
-
-// Returns volume dictionary which mounted at 'path'
-// 'path' is not necessary a mount point, it can be some path inside
-// mounted filesystem
-- (OSEUDisksVolume *)mountedVolumeForPath:(NSString *)filesystemPath
-{
-  NSEnumerator   *e = [[self mountedVolumes] objectEnumerator];
-  OSEUDisksVolume *volume = nil, *volume1 = nil;
-  NSString       *mp, *mp1;
-  NSString       *mountPoint = nil;
-
-  // Find longest mount point for path
-  mp = @"";
-  while ((volume1 = [e nextObject]) != nil)
-    {
-      mountPoint = [volume1 mountPoints];
-      // NSLog(@"LongestMP(%@): process MP: %@", filesystemPath, mountPoint);
-      mp1 = NXTIntersectionPath(filesystemPath, mountPoint);
-      if ([mp1 isEqualToString:mountPoint] && ([mp1 length] >= [mp length]))
-        {
-          ASSIGN(mp, mp1);
-          ASSIGN(volume, volume1);
-        }
-    }
-
-  NSDebugLLog(@"udisks", @"Longest MP: %@ for path %@",
-              [volume mountPoints], filesystemPath);
-
-  // if ([[volume mountPoints] isEqualToString:@"/"])
-  //   return nil;
-  // else
-    return [volume autorelease];
 }
 
 // 'path' is not necessary a mount point, it can be some path inside
 // mounted filesystem
 - (NXTFSType)filesystemTypeAtPath:(NSString *)filesystemPath
 {
-  OSEUDisksVolume *volume = [self mountedVolumeForPath:filesystemPath];
+  OSEUDisksVolume *volume = [self _mountedVolumeForPath:filesystemPath];
 
-  if (volume == nil)
-    {
-      return -1;
-    }
+  if (volume == nil) {
+    return -1;
+  }
 
-  return [volume type];
+  return [volume filesystemType];
 }
 
 // 'path' is not necessary a mount point, it can be some path inside
 // mounted filesystem
 - (NSString *)mountPointForPath:(NSString *)filesystemPath
 {
-  return [[self mountedVolumeForPath:filesystemPath] mountPoints];
+  return [[self _mountedVolumeForPath:filesystemPath] mountPoints][0];
 }
-
-// It's for 'disktool'
-// TODO: remove by fixing 'disktool'
-- (NSDictionary *)availableDrives
-{
-  return drives;
-}
-
-// Used by OSEUDisksDrive to collect it's volumes.
-// That's why we iterate registered volumes.
-- (NSDictionary *)availableVolumesForDrive:(NSString *)driveObjectPath
-{
-  NSArray             *volumePaths = [volumes allKeys];
-  OSEUDisksVolume      *volume;
-  NSMutableDictionary *driveVolumes = [NSMutableDictionary new];
-
-  for (NSString *path in volumePaths)
-    {
-      volume = [volumes objectForKey:path];
-      if ([[volume driveObjectPath] isEqualToString:driveObjectPath])
-        {
-          [driveVolumes setObject:volume forKey:path];
-        }
-    }
-  
-  return driveVolumes;
-}
-
-
-//--- Actions
 
 // Unmount filesystem mounted at subpath of 'path'.
 // Unmount only if FS resides on removable drive.
 // Async - OK.
 - (void)unmountRemovableVolumeAtPath:(NSString *)path
 {
-  OSEUDisksVolume *volume = [self mountedVolumeForPath:path];
+  OSEUDisksVolume *volume = [self _mountedVolumeForPath:path];
 
-  if (volume == nil)
-    {
-      return;
-    }
+  if (volume == nil) {
+    return;
+  }
 
   [volume unmount:NO];
 }
@@ -1188,89 +727,101 @@ static NSMutableDictionary *_dictionaryFromUDisksObject(UDisksObject *object)
 {
   NSMutableArray *mountPoints = [[NSMutableArray alloc] init];
 
-  for (OSEUDisksDrive  *drive in [drives allValues])
-    {
-      if ([drive isRemovable])
-        {
-          [mountPoints addObjectsFromArray:[drive mountVolumes:wait]];
-        }
+  for (OSEUDisksDrive *drive in [drives allValues]) {
+    if ([drive isRemovable]) {
+      [mountPoints addObjectsFromArray:[drive mountVolumes:wait]];
     }
+  }
 
   // Loop devices is always removable and have no drives
-  for (OSEUDisksVolume *volume in [volumes allValues])
-    {
-      if ([volume isLoopVolume] && [volume isFilesystem])
-        {
-          [volume mount:wait];
-        }
+  for (OSEUDisksVolume *volume in [volumes allValues]) {
+    if ([volume isLoopVolume] && [volume isFilesystem]) {
+      [volume mount:wait];
     }
-  
+  }
+
   return [mountPoints autorelease];
 }
-
 // ...mounts the disk asynchronously and returns immediately
 // Async - OK.
-   // NSWorkspace
+// NSWorkspace
 - (void)checkForRemovableMedia
 {
   [self _mountNewRemovableVolumesAndWait:NO];
 }
 
 // Check for unmounted removables and mount them.
-// Returns list of pathnames to newly mounted volumes (operation is synchronous).
+// Returns list of pathnames to newly mounted diskVolumes (operation is synchronous).
 // Sync - OK.
-   // NSWorkspace
+// NSWorkspace
 - (NSArray *)mountNewRemovableMedia
 {
   return [self _mountNewRemovableVolumesAndWait:YES];
 }
 
+// Returns list of pathnames to mount points of already mounted diskVolumes.
+// NSWorkspace
+- (NSArray *)mountedRemovableMedia
+{
+  NSArray *mountedVolumes = [self mountedVolumes];
+  NSMutableArray *mountPaths = [NSMutableArray new];
+
+  for (OSEUDisksVolume *volume in mountedVolumes) {
+    NSDebugLLog(@"udisks", @"OSEUDisksAdaptor: mountedRemovableMedia check: %@ (%@)", [volume mountPoints],
+                [[[[volume drive] properties] objectForKey:@"org.freedesktop.UDisks2.Drive"]
+                    objectForKey:@"Id"]);
+
+    if ([volume isFilesystem] &&
+        ([[volume drive] isRemovable] || [[volume drive] isMediaRemovable])) {
+      [mountPaths addObject:[volume mountPoints]];
+    }
+  }
+
+  NSDebugLLog(@"udisks", @"Adaptor: mountedRemovableMedia: %@", mountPaths);
+
+  return mountPaths;
+}
+
 // Unmounts and ejects device mounted at 'path'.
 // Async - OK.
-   // NSWorkspace
+// NSWorkspace
 - (void)unmountAndEjectDeviceAtPath:(NSString *)path
 {
   OSEUDisksVolume *volume, *loopMaster;
-  OSEUDisksDrive  *drive;
-  
+  OSEUDisksDrive *drive;
+
   // 1. Found volume mounted at subpath of 'path'
-  volume = [self mountedVolumeForPath:path];
+  volume = [self _mountedVolumeForPath:path];
 
   // 2. Found drive which contains volume
-  if (![volume isLoopVolume])
-    {
-      drive = [drives objectForKey:[volume driveObjectPath]];
-      // 3. Unmount all volumes mounted from that drive.
-      [drive unmountVolumesAndDetach];
-    }
-  else
-    {
-      // 3. Get loop master volume
-      loopMaster = [volume masterVolume];
-      NSLog(@"Eject loop volume: %@ (%@)", loopMaster, volume);
-      // 4. Unmount all loop volumes for that master
-      if (loopMaster != volume)
-        {
-          for (OSEUDisksVolume *vol in [volumes allValues])
-            {
-              NSLog(@">>%@", [vol UNIXDevice]);
-              if ([vol masterVolume] == loopMaster)
-                {
-                  NSLog(@"Unmount volume %@", [vol UNIXDevice]);
-                  [vol unmount:NO];
-                }
-            }
+  if (![volume isLoopVolume]) {
+    drive = [drives objectForKey:[volume driveObjectPath]];
+    // 3. Unmount all diskVolumes mounted from that drive.
+    [drive unmountVolumesAndDetach];
+  } else {
+    // 3. Get loop master volume
+    loopMaster = [volume masterVolume];
+    NSLog(@"Eject loop volume: %@ (%@)", loopMaster, volume);
+    // 4. Unmount all loop diskVolumes for that master
+    if (loopMaster != volume) {
+      for (OSEUDisksVolume *vol in [volumes allValues]) {
+        NSLog(@">>%@", [vol UNIXDevice]);
+        if ([vol masterVolume] == loopMaster) {
+          NSLog(@"Unmount volume %@", [vol UNIXDevice]);
+          [vol unmount:NO];
         }
-      // 5. Delete loop master volume
-      NSString *objectPath;
-      if ([volume isLoopVolume] && !loopMaster)
-        objectPath = [volume objectPath];
-      else
-        objectPath = [loopMaster objectPath];
-        
-      NSLog(@"Now delete loop device: %@", objectPath);
-      [self unsetLoop:objectPath];
+      }
     }
+    // 5. Delete loop master volume
+    // NSString *objectPath;
+    // if ([volume isLoopVolume] && !loopMaster)
+    //   objectPath = [volume objectPath];
+    // else
+    //   objectPath = [loopMaster objectPath];
+
+    // NSLog(@"Now delete loop device: %@", objectPath);
+    // [self unsetLoop:objectPath];
+  }
 }
 
 // Operation is synchronous.
@@ -1278,30 +829,28 @@ static NSMutableDictionary *_dictionaryFromUDisksObject(UDisksObject *object)
 - (void)ejectAllRemovables
 {
   // Loops first...
-  for (OSEUDisksVolume *volume in [volumes allValues])
-    {
-      if ([volume isLoopVolume])
-        {
-          [volume unmount:YES];
-        }
+  for (OSEUDisksVolume *volume in [volumes allValues]) {
+    if ([volume isLoopVolume]) {
+      [volume unmount:YES];
     }
+  }
 
   //...drives then
-  for (OSEUDisksDrive *drive in [drives allValues])
-    {
-      if ([drive isRemovable])
-        {
-          [drive unmountVolumesAndDetach];
-        }
+  for (OSEUDisksDrive *drive in [drives allValues]) {
+    if ([drive isRemovable]) {
+      [drive unmountVolumesAndDetach];
     }
+  }
 }
-
-//-- Loops
 
 - (BOOL)mountImageMediaFileAtPath:(NSString *)imageFile
 {
-  return [self setLoopToFileAtPath:imageFile];
+  // return [self setLoopToFileAtPath:imageFile];
+  return NO;
 }
+
+#if 0
+//-- Loops
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -1367,7 +916,26 @@ static NSMutableDictionary *_dictionaryFromUDisksObject(UDisksObject *object)
 
   return rc;
 }
+#endif
+
+//-------------------------------------------------------------------------------
+#pragma mark - DBus_ObjectManager protocol
+//-------------------------------------------------------------------------------
+
+- (NSArray *)GetManagedObjects
+{
+  OSEBusMessage *message;
+  id result;
+
+  message = [[OSEBusMessage alloc] initWithService:self
+                                         interface:@"org.freedesktop.DBus.ObjectManager"
+                                            method:@"GetManagedObjects"];
+  result = [message send];
+
+  [message release];
+
+  return result;
+}
 
 @end
 
-#endif // WITH_UDISKS

--- a/Frameworks/SystemKit/OSEUDisksAdaptor.m
+++ b/Frameworks/SystemKit/OSEUDisksAdaptor.m
@@ -159,24 +159,30 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
 {
   NSDebugLLog(@"UDisks", @"Removing and unregistering '%@'", objectPath);
   switch ([self _objectTypeForPath:objectPath]) {
-    case OSEOSEUDisksDriveObject:
+    case OSEOSEUDisksDriveObject: {
       // [OSEUDisksDrivesCache removeObjectForKey:objectPath];
+      OSEUDisksDrive *drive = drives[objectPath];
+      [drive removeSignalsObserving];
+      drive.udisksAdaptor = nil;
       [drives removeObjectForKey:objectPath];
       if (notify != NO) {
         [notificationCenter postNotificationName:OSEMediaDriveDidRemoveNotification
                                           object:self
                                         userInfo:@{@"ObjectPath" : objectPath}];
       }
-      break;
-    case OSEUDisksBlockObject:
+    } break;
+    case OSEUDisksBlockObject: {
       // [udisksBlockDevicesCache removeObjectForKey:objectPath];
+      OSEUDisksVolume *volume = volumes[objectPath];
+      [volume removeSignalsObserving];
+      volume.udisksAdaptor = nil;
       [volumes removeObjectForKey:objectPath];
       if (notify != NO) {
         [notificationCenter postNotificationName:OSEMediaVolumeDidRemoveNotification
                                           object:self
                                         userInfo:@{@"ObjectPath" : objectPath}];
       }
-      break;
+    } break;
     case OSEUDisksJobObject:
       // TODO
       [jobsCache removeObjectForKey:objectPath];
@@ -516,16 +522,16 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
     OSEUDisksVolume *volume = volumes[key];
     NSDebugLLog(@"dealloc", @"OSEUDisksAdaptor: -dealloc - `Volume` - %@ retain count %lu.",
                 [volume objectPath], [volume retainCount]);
+    [volume removeSignalsObserving];
     volume.udisksAdaptor = nil;
-    // [volume removeSignalsObserving];
   }
   [volumes release];
   for (NSString *key in [drives allKeys]) {
     OSEUDisksDrive *drive = drives[key];
     NSDebugLLog(@"dealloc", @"OSEUDisksAdaptor: -dealloc - `Drive` - %@ retain count %lu.",
                 [drive objectPath], [drive retainCount]);
+    [drive removeSignalsObserving];
     drive.udisksAdaptor = nil;
-    // [drive removeSignalsObserving];
   }
   [drives release];
   [jobsCache release];

--- a/Frameworks/SystemKit/OSEUDisksAdaptor.m
+++ b/Frameworks/SystemKit/OSEUDisksAdaptor.m
@@ -380,18 +380,16 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
                         notification:OSEUDisksInterfacesDidRemoveNotification];
 }
 
-- (void)handlePropertiesChangedSignal:(NSNotification *)aNotif
+- (void)handlePropertiesChangedSignal:(NSDictionary *)info
 {
-  NSDebugLLog(@"UDisks", @"OSEUDisksAdaptor \e[1mPropertiesChanged\e[0m: %@",
-             aNotif.userInfo[@"Message"]);
+  NSDebugLLog(@"UDisks", @"OSEUDisksAdaptor \e[1mPropertiesChanged\e[0m: %@", info[@"Message"]);
 }
 
-- (void)handleInterfacesAdeddSignal:(NSNotification *)aNotif
+- (void)handleInterfacesAdeddSignal:(NSDictionary *)info
 {
-  NSDebugLLog(@"UDisks", @"OSEUDisksAdaptor \e[1mInterfacesAdded\e[0m: %@",
-             aNotif.userInfo[@"Message"]);
+  NSDebugLLog(@"UDisks", @"OSEUDisksAdaptor \e[1mInterfacesAdded\e[0m: %@", info[@"Message"]);
 
-  NSArray *message = aNotif.userInfo[@"Message"];
+  NSArray *message = info[@"Message"];
   NSString *objectPath = nil;
   NSArray *objectProperties = nil;
 
@@ -468,11 +466,10 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
   }
 }
 
-- (void)handleInterfacesRemovedSignal:(NSNotification *)aNotif
+- (void)handleInterfacesRemovedSignal:(NSDictionary *)info
 {
-  NSDebugLLog(@"UDisks", @"OSEUDisksAdaptor \e[1mInterfacesRemoved\e[0m: %@",
-             aNotif.userInfo[@"Message"]);
-  NSArray *message = aNotif.userInfo[@"Message"];
+  NSDebugLLog(@"UDisks", @"OSEUDisksAdaptor \e[1mInterfacesRemoved\e[0m: %@", info[@"Message"]);
+  NSArray *message = info[@"Message"];
   NSString *objectPath;
 
   if (message.count == 0) {
@@ -533,6 +530,9 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
   [volumes release];
   [drives release];
   [jobsCache release];
+
+  // OSEUDisksAdaptor is the main owner of connection to UDisks2 D-Bus service (OSEBusConnection) - release it.
+  [self.connection release];
 
   [super dealloc];
 }

--- a/Frameworks/SystemKit/OSEUDisksAdaptor.m
+++ b/Frameworks/SystemKit/OSEUDisksAdaptor.m
@@ -422,7 +422,7 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
         [volume _dumpProperties];
         [properties release];
       }
-      [[volumes objectForKey:objectPath] mount:YES];
+      // [[volumes objectForKey:objectPath] mount:YES];
     } break;
     case OSEUDisksJobObject: {
       // TODO
@@ -494,7 +494,7 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
       if (object.properties.allKeys.count == 0) {
         [self _removeObject:objectPath andNotify:YES];
       }
-      [object _dumpProperties];
+      // [object _dumpProperties];
     }
   }
 }

--- a/Frameworks/SystemKit/OSEUDisksAdaptor.m
+++ b/Frameworks/SystemKit/OSEUDisksAdaptor.m
@@ -149,7 +149,7 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
 
 - (void)_parseObject:(NSString *)objectPath withProperties:(NSArray *)objectProperties
 {
-  NSLog(@"Parsing '%@'", objectPath);
+  NSDebugLLog(@"UDisks", @"Parsing '%@'", objectPath);
   switch ([self _objectTypeForPath:objectPath]) {
     case OSEOSEUDisksDriveObject:
       [self _parseDrive:objectPath withProperties:objectProperties];
@@ -160,7 +160,9 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
     case OSEUDisksJobObject:
       break;
     default:
-      NSLog(@"OSEUDisksAdaptor Warning: trying to append unknown object type with path '%@'", objectPath);
+      NSDebugLLog(@"UDisks",
+                 @"OSEUDisksAdaptor Warning: trying to append unknown object type with path '%@'",
+                 objectPath);
   }
 }
 
@@ -168,7 +170,7 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
 
 - (void)_removeObject:(NSString *)objectPath andNotify:(BOOL)notify
 {
-  NSLog(@"Removing and unregistering '%@'", objectPath);
+  NSDebugLLog(@"UDisks", @"Removing and unregistering '%@'", objectPath);
   switch ([self _objectTypeForPath:objectPath]) {
     case OSEOSEUDisksDriveObject:
       // [OSEUDisksDrivesCache removeObjectForKey:objectPath];
@@ -193,7 +195,9 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
       [jobsCache removeObjectForKey:objectPath];
       break;
     default:
-      NSLog(@"OSEUDisksAdaptor Warning: trying to remove unknown object type with path %@", objectPath);
+      NSDebugLLog(@"UDisks",
+                 @"OSEUDisksAdaptor Warning: trying to remove unknown object type with path %@",
+                 objectPath);
   }
 }
 
@@ -232,11 +236,12 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
   [udisksBlockDevicesCache removeObjectForKey:objectPath];
 
   drivePath = blockDevice[BLOCK_INTERFACE][@"Drive"];
-  // NSLog(@"_registerBlockDevice: %@", blockDevice);
+  // NSDebugLLog(@"UDisks", @"_registerBlockDevice: %@", blockDevice);
   drive = [drives objectForKey:drivePath];
   if (drive == nil) {
-    NSLog(@"OSEUDisksAdaptor Warning: no drive with path '%@' found for block device '%@'", drivePath,
-          objectPath);
+    NSDebugLLog(@"UDisks",
+               @"OSEUDisksAdaptor Warning: no drive with path '%@' found for block device '%@'",
+               drivePath, objectPath);
     return;
   }
   [drive addVolume:volumeInstance withPath:objectPath];
@@ -300,7 +305,7 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
   mp = @"";
   for (OSEUDisksVolume *volume1 in [self mountedVolumes]) {
     mountPoint = [volume1 mountPoints][0];
-    // NSLog(@"LongestMP(%@): process MP: %@", filesystemPath, mountPoint);
+    // NSDebugLLog(@"UDisks", @"LongestMP(%@): process MP: %@", filesystemPath, mountPoint);
     mp1 = NXTIntersectionPath(filesystemPath, mountPoint);
     if ([mp1 isEqualToString:mountPoint] && ([mp1 length] >= [mp length])) {
       ASSIGN(mp, mp1);
@@ -373,12 +378,14 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
 
 - (void)handlePropertiesChangedSignal:(NSNotification *)aNotif
 {
-  NSLog(@"OSEUDisksAdaptor \e[1mPropertiesChanged\e[0m: %@", aNotif.userInfo[@"Message"]);
+  NSDebugLLog(@"UDisks", @"OSEUDisksAdaptor \e[1mPropertiesChanged\e[0m: %@",
+             aNotif.userInfo[@"Message"]);
 }
 
 - (void)handleInterfacesAdeddSignal:(NSNotification *)aNotif
 {
-  NSLog(@"OSEUDisksAdaptor \e[1mInterfacesAdded\e[0m: %@", aNotif.userInfo[@"Message"]);
+  NSDebugLLog(@"UDisks", @"OSEUDisksAdaptor \e[1mInterfacesAdded\e[0m: %@",
+             aNotif.userInfo[@"Message"]);
 
   NSArray *message = aNotif.userInfo[@"Message"];
   NSString *objectPath = nil;
@@ -388,7 +395,8 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
     objectPath = message[0];
     objectProperties = message[1];
   } else {
-    NSLog(@"OSEUDisksAdaptor error: message in InterfaceAdded notification is broken.");
+    NSDebugLLog(@"UDisks",
+               @"OSEUDisksAdaptor error: message in InterfaceAdded notification is broken.");
     return;
   }
 
@@ -450,18 +458,22 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
       [jobsCache setObject:properties forKey:objectPath];
     } break;
     default:
-      NSLog(@"OSEUDisksAdaptor Warning: trying to remove unknown object type with path %@", objectPath);
+      NSDebugLLog(@"UDisks",
+                 @"OSEUDisksAdaptor Warning: trying to remove unknown object type with path %@",
+                 objectPath);
   }
 }
 
 - (void)handleInterfacesRemovedSignal:(NSNotification *)aNotif
 {
-  NSLog(@"OSEUDisksAdaptor \e[1mInterfacesRemoved\e[0m: %@", aNotif.userInfo[@"Message"]);
+  NSDebugLLog(@"UDisks", @"OSEUDisksAdaptor \e[1mInterfacesRemoved\e[0m: %@",
+             aNotif.userInfo[@"Message"]);
   NSArray *message = aNotif.userInfo[@"Message"];
   NSString *objectPath;
 
   if (message.count == 0) {
-    NSLog(@"OSEUDisksAdaptor InterfacesRemoved warning: no object path specified in message.");
+    NSDebugLLog(@"UDisks",
+               @"OSEUDisksAdaptor InterfacesRemoved warning: no object path specified in message.");
     return;
   } else {
     objectPath = message.firstObject;
@@ -484,7 +496,8 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
         [jobsCache removeObjectForKey:objectPath];
       } break;
       default:
-        NSLog(@"OSEUDisksAdaptor InterfacesRemoved warning: unknown object type was removed, skipping.");
+        NSDebugLLog(@"UDisks", @"OSEUDisksAdaptor InterfacesRemoved warning: unknown object type "
+                              @"was removed, skipping.");
         break;
     }
     if (object != nil) {
@@ -595,7 +608,9 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
       object = [jobsCache objectForKey:objectPath];
       break;
     default:
-      NSLog(@"OSEUDisksAdaptor objectWithUDisksPath: unknow object for object path %@", objectPath);
+      NSDebugLLog(@"UDisks",
+                 @"OSEUDisksAdaptor objectWithUDisksPath: unknow object for object path %@",
+                 objectPath);
   }
   
   return object;
@@ -664,7 +679,9 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
       [info setObject:[object UNIXDevice] forKey:@"UNIXDevice"];
 
       if ([name isEqualToString:@"Mount"] && !failed) {
-        [info setObject:[object mountPoints] forKey:@"MountPoint"];
+        if ([object mountPoints].count > 0) {
+          [info setObject:[object mountPoints] forKey:@"MountPoint"];
+        }
         [notificationCenter postNotificationName:OSEMediaVolumeDidMountNotification
                                           object:self
                                         userInfo:info];
@@ -821,13 +838,13 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
   } else {
     // 3. Get loop master volume
     loopMaster = [volume masterVolume];
-    NSLog(@"Eject loop volume: %@ (%@)", loopMaster, volume);
+    NSDebugLLog(@"UDisks", @"Eject loop volume: %@ (%@)", loopMaster, volume);
     // 4. Unmount all loop diskVolumes for that master
     if (loopMaster != volume) {
       for (OSEUDisksVolume *vol in [volumes allValues]) {
-        NSLog(@">>%@", [vol UNIXDevice]);
+        NSDebugLLog(@"UDisks", @">>%@", [vol UNIXDevice]);
         if ([vol masterVolume] == loopMaster) {
-          NSLog(@"Unmount volume %@", [vol UNIXDevice]);
+          NSDebugLLog(@"UDisks", @"Unmount volume %@", [vol UNIXDevice]);
           [vol unmount:NO];
         }
       }

--- a/Frameworks/SystemKit/OSEUDisksAdaptor.m
+++ b/Frameworks/SystemKit/OSEUDisksAdaptor.m
@@ -206,7 +206,9 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
   OSEUDisksDrive *driveInstance;
   NSDictionary *drive = OSEUDisksDrivesCache[objectPath];
 
-  driveInstance = [[OSEUDisksDrive alloc] initWithProperties:drive objectPath:objectPath];
+  driveInstance = [[OSEUDisksDrive alloc] initWithProperties:drive
+                                                  objectPath:objectPath
+                                                     adaptor:self];
   driveInstance.udisksAdaptor = self;
   [OSEUDisksDrivesCache removeObjectForKey:objectPath];
 
@@ -230,7 +232,9 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
     // Ignored devices leaves in the cache
     return;
   }
-  volumeInstance = [[OSEUDisksVolume alloc] initWithProperties:blockDevice objectPath:objectPath];
+  volumeInstance = [[OSEUDisksVolume alloc] initWithProperties:blockDevice
+                                                    objectPath:objectPath
+                                                       adaptor:self];
   volumeInstance.udisksAdaptor = self;
   [volumes setObject:volumeInstance forKey:objectPath];
   [udisksBlockDevicesCache removeObjectForKey:objectPath];
@@ -354,12 +358,12 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
 
 - (void)setSignalsMonitoring
 {
-  [self.connection addSignalObserver:self
-                            selector:@selector(handlePropertiesChangedSignal:)
-                              signal:@"PropertiesChanged"
-                              object:self.objectPath
-                           interface:@"org.freedesktop.DBus.Properties"
-                        notification:OSEUDisksPropertiesDidChangeNotification];
+  // [self.connection addSignalObserver:self
+  //                           selector:@selector(handlePropertiesChangedSignal:)
+  //                             signal:@"PropertiesChanged"
+  //                             object:self.objectPath
+  //                          interface:@"org.freedesktop.DBus.Properties"
+  //                       notification:OSEUDisksPropertiesDidChangeNotification];
   
   [self.connection addSignalObserver:self
                             selector:@selector(handleInterfacesAdeddSignal:)

--- a/Frameworks/SystemKit/OSEUDisksAdaptor.m
+++ b/Frameworks/SystemKit/OSEUDisksAdaptor.m
@@ -28,11 +28,6 @@
 
 #import "OSEUDisksAdaptor.h"
 
-// Signals
-NSString *OSEUDisksInterfacesDidAddNotification = @"OSEUDisksInterfacesDidAddNotification";
-NSString *OSEUDisksInterfacesDidRemoveNotification = @"OSEUDisksInterfacesDidRemoveNotification";
-NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidChangeNotification";
-
 @implementation OSEUDisksAdaptor (Utility)
 
 - (OSEUDisksObject)_objectTypeForPath:(NSString *)objectPath
@@ -424,7 +419,7 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
       // NSString *objectPath = message[0];
       // NSArray *jobProperties = message[1];
       properties = [self _parsePropertiesSection:objectProperties.firstObject[JOB_INTERFACE]];
-      NSLog(@"Adding Job %@", objectPath);
+      NSDebugLLog(@"UDisks", @"Adding Job %@", objectPath);
       [jobsCache setObject:properties forKey:objectPath];
       NSArray *objects = properties[@"Objects"];
       // [self operationWithName:[self _operationNameForJobInfo:properties]
@@ -472,7 +467,7 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
         NSDictionary *properties = jobsCache[objectPath];
         NSArray *objects = properties[@"Objects"];
         id<UDisksObject> obj = [self objectWithUDisksPath:objects.firstObject];
-        NSLog(@"Removing Job %@ - %@", objectPath, properties);
+        NSDebugLLog(@"UDisks", @"Removing Job %@ - %@", objectPath, properties);
         // [self
         //     operationWithName:[self _operationNameForJobInfo:properties]
         //                object:obj

--- a/Frameworks/SystemKit/OSEUDisksAdaptor.m
+++ b/Frameworks/SystemKit/OSEUDisksAdaptor.m
@@ -338,11 +338,11 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
     return @"Mount";
   } else if ([operation isEqualToString:@"filesystem-unmount"]) {
     return @"Unmount";
-  } else {
+  } else if ([operation isEqualToString:@"drive-eject"]) {
     return @"Eject";
   }
 
-  return nil;
+  return operation;
 }
 
 - (void)handleInterfacesAdeddSignal:(NSDictionary *)info
@@ -421,12 +421,12 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
       NSLog(@"Adding Job %@", objectPath);
       [jobsCache setObject:properties forKey:objectPath];
       NSArray *objects = properties[@"Objects"];
-      [self operationWithName:[self _operationNameForJobInfo:properties]
-                       object:[self objectWithUDisksPath:objects.firstObject]
-                       failed:NO
-                       status:@"Started"
-                        title:@"Operation has been started."
-                      message:@"UDisks Job was added."];
+      // [self operationWithName:[self _operationNameForJobInfo:properties]
+      //                  object:[self objectWithUDisksPath:objects.firstObject]
+      //                  failed:NO
+      //                  status:@"Started"
+      //                   title:@"Operation has been started."
+      //                 message:@"UDisks Job was added."];
     } break;
     default:
       NSDebugLLog(@"UDisks",
@@ -467,16 +467,16 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
         NSArray *objects = properties[@"Objects"];
         id<UDisksObject> obj = [self objectWithUDisksPath:objects.firstObject];
         NSLog(@"Removing Job %@ - %@", objectPath, properties);
-        [self
-            operationWithName:[self _operationNameForJobInfo:properties]
-                       object:obj
-                       failed:NO
-                       status:@"Completed"
-                        title:@"Operation has been completed."
-                      message:[NSString stringWithFormat:
-                                            @"UDisks Job was removed.\nOperation: %@ \nObject: %@",
-                                            [self _operationNameForJobInfo:properties],
-                                            obj.objectPath]];
+        // [self
+        //     operationWithName:[self _operationNameForJobInfo:properties]
+        //                object:obj
+        //                failed:NO
+        //                status:@"Completed"
+        //                 title:@"Operation has been completed."
+        //               message:[NSString stringWithFormat:
+        //                                     @"UDisks Job was removed.\nOperation: %@ \nObject: %@",
+        //                                     [self _operationNameForJobInfo:properties],
+        //                                     obj.objectPath]];
         [jobsCache removeObjectForKey:objectPath];
       } break;
       default:
@@ -647,7 +647,7 @@ NSString *OSEUDisksPropertiesDidChangeNotification = @"OSEUDisksPropertiesDidCha
 {
   NSMutableDictionary *info = [NSMutableDictionary new];
 
-  [info setObject:object forKey:@"ID"];
+  [info setObject:[object objectPath] forKey:@"ID"];
   [info setObject:name forKey:@"Operation"];
   [info setObject:title forKey:@"Title"];
   [info setObject:message forKey:@"Message"];

--- a/Frameworks/SystemKit/OSEUDisksDrive.h
+++ b/Frameworks/SystemKit/OSEUDisksDrive.h
@@ -24,50 +24,45 @@
  * UDisks base path is: "/org/freedesktop/UDisks2/drives/<name of drive>".
  */
 
-#ifdef WITH_UDISKS
-
 #import <SystemKit/OSEMediaManager.h>
-#import <SystemKit/OSEUDisksAdaptor.h>
+#import "OSEUDisksAdaptor.h"
 
 @class OSEUDisksVolume;
 
-@interface OSEUDisksDrive : NSObject <UDisksMedia>
+@interface OSEUDisksDrive : NSObject <UDisksObject>
 {
-  OSEUDisksAdaptor      *adaptor;
-  NSMutableDictionary  *properties;
-  NSString             *objectPath;
-  
-  NSMutableDictionary  *volumes;
+  NSMutableArray *mountedVolumesToDetach;
+  BOOL needsDetach;
 
   NSNotificationCenter *notificationCenter;
-
-  NSMutableArray *mountedVolumesToDetach;
-  BOOL           needsDetach;
 }
 
+//--- Protocol
+@property (readonly) NSMutableDictionary *properties;
+@property (readonly) NSString *objectPath;
+
 //--- Object network
-- (NSDictionary *)volumes;
+@property (readwrite, assign) OSEUDisksAdaptor *udisksAdaptor;
+@property (readonly) NSMutableDictionary *volumes;
 - (void)addVolume:(OSEUDisksVolume *)volume withPath:(NSString *)volumePath;
 - (void)removeVolumeWithKey:(NSString *)key;
-- (NSString *)objectPath;
 
 //--- Attributes
-- (NSString *)UNIXDevice;
-- (NSString *)humanReadableName; // vendor, model
-- (BOOL)isRemovable;
-- (BOOL)isEjectable;
-- (BOOL)canPowerOff;
+@property (readonly) NSString *humanReadableName;  // vendor, model
+@property (readonly) BOOL isRemovable;
+@property (readonly) BOOL isEjectable;
+@property (readonly) BOOL canPowerOff;
 
 // valuable for optical disks
-- (BOOL)isOptical;
-- (BOOL)hasMedia;
-- (BOOL)isMediaRemovable;
-- (BOOL)isOpticalBlank;
-- (NSString *)numberOfAudioTracks;
-- (NSString *)numberOfDataTracks;
+@property (readonly) BOOL isOptical;
+@property (readonly) BOOL hasMedia;
+@property (readonly) BOOL isMediaRemovable;
+@property (readonly) BOOL isOpticalBlank;
+@property (readonly) NSNumber *numberOfAudioTracks;
+@property (readonly) NSNumber *numberOfDataTracks;
 
 //--- Actions
-- (NSArray *)mountedVolumes;
+@property (readonly) NSArray *mountedVolumes;
 - (NSArray *)mountVolumes:(BOOL)wait;
 - (BOOL)unmountVolumes:(BOOL)wait;
 - (void)unmountVolumesAndDetach;
@@ -75,5 +70,3 @@
 - (BOOL)powerOff:(BOOL)wait;
 
 @end
-
-#endif //WITH_UDISKS

--- a/Frameworks/SystemKit/OSEUDisksDrive.h
+++ b/Frameworks/SystemKit/OSEUDisksDrive.h
@@ -44,8 +44,6 @@
 //--- Object network
 @property (readwrite, assign) OSEUDisksAdaptor *udisksAdaptor;
 @property (readonly) NSMutableDictionary *volumes;
-- (void)addVolume:(OSEUDisksVolume *)volume withPath:(NSString *)volumePath;
-- (void)removeVolumeWithKey:(NSString *)key;
 
 //--- Attributes
 @property (readonly) NSString *humanReadableName;  // vendor, model

--- a/Frameworks/SystemKit/OSEUDisksDrive.h
+++ b/Frameworks/SystemKit/OSEUDisksDrive.h
@@ -43,7 +43,7 @@
 
 //--- Object network
 @property (readwrite, assign) OSEUDisksAdaptor *udisksAdaptor;
-@property (readonly) NSMutableDictionary *volumes;
+// @property (readonly) NSMutableDictionary *volumes;
 
 //--- Attributes
 @property (readonly) NSString *humanReadableName;  // vendor, model

--- a/Frameworks/SystemKit/OSEUDisksDrive.m
+++ b/Frameworks/SystemKit/OSEUDisksDrive.m
@@ -302,7 +302,7 @@ NSLock *driveLock = nil;
 // Not implemented
 - (void)unmountVolumesAndDetach
 {
-  NSLog(@"OSEOSEUDisksDrive -unmountVolumesAndDetach is not implemented yet");
+  NSDebugLLog(@"UDisks", @"OSEOSEUDisksDrive -unmountVolumesAndDetach is not implemented yet");
   // 1.
   NSString *message;
   message = [NSString stringWithFormat:@"Ejecting %@...", [self humanReadableName]];
@@ -349,7 +349,7 @@ NSLock *driveLock = nil;
   }
 
   NSDebugLLog(@"udisks", @"Drive: Eject the Drive: %@", _objectPath);
-  NSLog(@"OSEOSEUDisksDrive: eject: %@", _objectPath);
+  NSDebugLLog(@"UDisks", @"OSEOSEUDisksDrive: eject: %@", _objectPath);
 
   message = [NSString stringWithFormat:@"Ejecting drive %@", [self humanReadableName]];
   [_udisksAdaptor operationWithName:@"Eject"
@@ -370,7 +370,7 @@ NSLock *driveLock = nil;
     result = [busMessage sendWithConnection:_udisksAdaptor.connection];
     [busMessage release];
 
-    NSLog(@"OSEUDisksVolume -eject result: %@", result);
+    NSDebugLLog(@"UDisks", @"OSEUDisksVolume -eject result: %@", result);
     if ([result isKindOfClass:[NSError class]]) {
       message = [(NSError *)result userInfo][@"Description"];
       [_udisksAdaptor operationWithName:@"Eject"
@@ -391,7 +391,7 @@ NSLock *driveLock = nil;
       return YES;
     }
   } else {
-    NSLog(@"Warning: Asynchronous volume mounting is not implemented!");
+    NSDebugLLog(@"UDisks", @"Warning: Asynchronous volume mounting is not implemented!");
   }
 
   return NO;
@@ -408,8 +408,7 @@ NSLock *driveLock = nil;
     return NO;
   }
 
-  NSDebugLLog(@"udisks", @"Drive: PowerOff the Drive: %@", _objectPath);
-  NSLog(@"OSEOSEUDisksDrive: powerOff: %@", _objectPath);
+  NSDebugLLog(@"UDisks", @"OSEOSEUDisksDrive: powerOff the drive %@", _objectPath);
 
   message = [NSString stringWithFormat:@"Power off the drive %@", [self humanReadableName]];
   [_udisksAdaptor operationWithName:@"PowerOff"
@@ -430,7 +429,7 @@ NSLock *driveLock = nil;
     result = [busMessage sendWithConnection:_udisksAdaptor.connection];
     [busMessage release];
 
-    NSLog(@"OSEUDisksVolume -eject result: %@", result);
+    NSDebugLLog(@"UDisks", @"OSEUDisksVolume -eject result: %@", result);
     if ([result isKindOfClass:[NSError class]]) {
       message = [(NSError *)result userInfo][@"Description"];
       [_udisksAdaptor operationWithName:@"PowerOff"
@@ -451,7 +450,7 @@ NSLock *driveLock = nil;
       return YES;
     }
   } else {
-    NSLog(@"Warning: Asynchronous volume mounting is not implemented!");
+    NSDebugLLog(@"UDisks", @"Warning: Asynchronous volume mounting is not implemented!");
   }
 
   return NO;

--- a/Frameworks/SystemKit/OSEUDisksDrive.m
+++ b/Frameworks/SystemKit/OSEUDisksDrive.m
@@ -34,6 +34,7 @@
 {
   NSString *fileName;
   NSMutableDictionary *props = [_properties mutableCopy];
+  NSDictionary *_volumes = [_udisksAdaptor availableVolumesForDrive:_objectPath];
 
   fileName =
       [NSString stringWithFormat:@"Library/Workspace/Drive_%@", [_objectPath lastPathComponent]];
@@ -49,7 +50,7 @@
   NSDebugLLog(@"dealloc", @"OSEUDisksDrive -dealloc %@", self.objectPath);
   [_properties release];
   [_objectPath release];
-  [_volumes release];
+  // [_volumes release];
 
   [super dealloc];
 }
@@ -62,7 +63,7 @@
 
   _properties = [properties mutableCopy];
   _objectPath = [path copy];
-  _volumes = [[NSMutableDictionary alloc] init];
+  // _volumes = [[NSMutableDictionary alloc] init];
   self.udisksAdaptor = adaptor;
 
   notificationCenter = [NSNotificationCenter defaultCenter];
@@ -196,6 +197,7 @@
 //-------------------------------------------------------------------------------
 - (NSArray *)mountedVolumes
 {
+  NSDictionary *_volumes = [_udisksAdaptor availableVolumesForDrive:_objectPath];
   NSMutableArray *mountedVolumes = [NSMutableArray array];
   OSEUDisksVolume *volume;
 
@@ -214,6 +216,7 @@
 
 - (NSArray *)mountVolumes:(BOOL)wait
 {
+  NSDictionary *_volumes = [_udisksAdaptor availableVolumesForDrive:_objectPath];
   NSMutableArray *mountPoints = [NSMutableArray array];
   OSEUDisksVolume *volume;
   NSString *mp;
@@ -232,12 +235,13 @@
 
 - (BOOL)unmountVolumes:(BOOL)wait
 {
+  NSDictionary *volumes = [_udisksAdaptor availableVolumesForDrive:_objectPath];
   OSEUDisksVolume *volume;
 
-  NSDebugLLog(@"UDisks", @"Drive: unmountVolumes: %@", _volumes);
+  NSDebugLLog(@"UDisks", @"Drive: unmountVolumes: %@", volumes);
 
-  for (NSString *key in [_volumes allKeys]) {
-    volume = _volumes[key];
+  for (NSString *key in [volumes allKeys]) {
+    volume = volumes[key];
     if (![volume unmount:wait]) {
       return NO;
     }

--- a/Frameworks/SystemKit/OSEUDisksDrive.m
+++ b/Frameworks/SystemKit/OSEUDisksDrive.m
@@ -409,7 +409,16 @@ NSLock *driveLock = nil;
       return YES;
     }
   } else {
-    NSDebugLLog(@"UDisks", @"Warning: Asynchronous volume mounting is not implemented!");
+    NSDebugLLog(@"UDisks", @"Warning: Asynchronous drive ejecting is not implemented!");
+    message = [NSString stringWithFormat:@"Eject of %@ completed at mount point %@",
+                                         [self humanReadableName], result];
+    [_udisksAdaptor operationWithName:@"Eject"
+                               object:self
+                               failed:NO
+                               status:@"Completed"
+                                title:@"Eject"
+                              message:message];
+    return YES;
   }
 
   return NO;

--- a/Frameworks/SystemKit/OSEUDisksDrive.m
+++ b/Frameworks/SystemKit/OSEUDisksDrive.m
@@ -54,12 +54,14 @@
 
 - (id)initWithProperties:(NSDictionary *)properties
               objectPath:(NSString *)path
+                 adaptor:(OSEUDisksAdaptor *)adaptor
 {
   self = [super init];
 
   _properties = [properties mutableCopy];
   _objectPath = [path copy];
   _volumes = [[NSMutableDictionary alloc] init];
+  self.udisksAdaptor = adaptor;
 
   notificationCenter = [NSNotificationCenter defaultCenter];
 

--- a/Frameworks/SystemKit/OSEUDisksDrive.m
+++ b/Frameworks/SystemKit/OSEUDisksDrive.m
@@ -387,7 +387,7 @@ NSLock *driveLock = nil;
   // 2.1 Subscribe to notifications
   [notificationCenter addObserver:self
                          selector:@selector(volumeDidUnmount:)
-                             name:NXVolumeUnmounted
+                             name:OSEMediaVolumeDidUnmountNotification
                            object:adaptor];
 
   // 3.

--- a/Frameworks/SystemKit/OSEUDisksDrive.m
+++ b/Frameworks/SystemKit/OSEUDisksDrive.m
@@ -289,12 +289,12 @@ NSLock *driveLock = nil;
                                                [self humanReadableName]];
         }
       }
-      [_udisksAdaptor operationWithName:@"Eject"
-                                 object:self
-                                 failed:NO
-                                 status:@"Completed"
-                                  title:@"Disk Eject"
-                                message:message];
+      // [_udisksAdaptor operationWithName:@"Eject"
+      //                            object:self
+      //                            failed:NO
+      //                            status:@"Completed"
+      //                             title:@"Disk Eject"
+      //                           message:message];
       [[NSNotificationCenter defaultCenter] removeObserver:self];
       needsDetach = NO;
       [mountedVolumesToDetach release];
@@ -351,6 +351,15 @@ NSLock *driveLock = nil;
                                status:@"Completed"
                                 title:@"Disk Eject"
                               message:message];
+  } else {
+    message = [NSString stringWithFormat:@"Ejecting of '%@' completed", [self humanReadableName]];
+    [_udisksAdaptor operationWithName:@"Eject"
+                               object:self
+                               failed:NO
+                               status:@"Completed"
+                                title:@"Disk Eject"
+                              message:message];
+
   }
 
   // // 4. & 5. are in [self volumeDidUnmount:].

--- a/Frameworks/SystemKit/OSEUDisksVolume.h
+++ b/Frameworks/SystemKit/OSEUDisksVolume.h
@@ -34,7 +34,6 @@
 
 @interface OSEUDisksVolume : NSObject <UDisksObject>
 {
-  NSNotificationCenter *notificationCenter;
 }
 
 - (void)_dumpProperties;

--- a/Frameworks/SystemKit/OSEUDisksVolume.h
+++ b/Frameworks/SystemKit/OSEUDisksVolume.h
@@ -20,54 +20,55 @@
 //
 
 /*
- * OSEUDisksVolume.h
- * 
+ * OSEOSEOSEUDisksVolume.h
+ *
  * Media object which treated by UDisks as 'block_devices' object.
  * Can contain filesystem, swap, extended partition, RAID volume.
  */
 
-#ifdef WITH_UDISKS
-
 #import <SystemKit/OSEMediaManager.h>
-#import <SystemKit/OSEUDisksAdaptor.h>
+#import "OSEUDisksAdaptor.h"
 
+@class OSEUDisksAdaptor;
 @class OSEUDisksDrive;
 
-@interface OSEUDisksVolume : NSObject <UDisksMedia>
+@interface OSEUDisksVolume : NSObject <UDisksObject>
 {
-  OSEUDisksAdaptor     *adaptor;
-  NSMutableDictionary *properties;
-  NSString            *objectPath;
-  OSEUDisksDrive       *drive;
-
   NSNotificationCenter *notificationCenter;
 }
 
-//--- Parent object
-- (OSEUDisksAdaptor *)adaptor;
-- (OSEUDisksDrive *)drive;
-- (void)setDrive:(OSEUDisksDrive *)driveObject;
+- (void)_dumpProperties;
+
+//--- Protocol
+@property (readonly) NSMutableDictionary *properties;
+@property (readonly) NSString *objectPath;
+
+//--- Parent objects
+@property (readwrite, assign) OSEUDisksAdaptor *udisksAdaptor;
+@property (readwrite, assign) OSEUDisksDrive *drive;
 - (OSEUDisksVolume *)masterVolume;
 - (NSString *)driveObjectPath;
 
 //--- Accessories
-- (NXTFSType)type;
-- (NSString *)UUID;
-- (NSString *)label;
-- (NSString *)size;
-- (NSString *)UNIXDevice;
-- (NSString *)mountPoints;
+@property (readonly) NSString *UUID;
+@property (readonly) NSString *UNIXDevice;
+@property (readonly) NSNumber *size;
+@property (readonly) BOOL isSystem;
 
-- (NSString *)partitionType;
-- (NSString *)partitionNumber;
-- (NSString *)partitionSize;
+@property (readonly) BOOL hasPartition;
+@property (readonly) NSString *partitionType;
+@property (readonly) NSNumber *partitionNumber;
+@property (readonly) NSNumber *partitionSize;
 
-- (BOOL)isFilesystem;
-- (BOOL)isMounted;
-- (BOOL)isWritable;
+@property (readonly) BOOL isFilesystem;
+@property (readonly) NXTFSType filesystemType;
+@property (readonly) NSString *filesystemName;
+@property (readonly) NSString *label;
+@property (readonly) NSArray *mountPoints;
+@property (readonly) BOOL isMounted;
+@property (readonly) BOOL isWritable;
 
-- (BOOL)isLoopVolume;
-- (BOOL)isSystem;
+@property (readonly) BOOL isLoopVolume;
 
 //--- Actions
 
@@ -78,5 +79,3 @@
 - (BOOL)unmount:(BOOL)wait;
 
 @end
-
-#endif // WITH_UDISKS

--- a/Frameworks/SystemKit/OSEUDisksVolume.h
+++ b/Frameworks/SystemKit/OSEUDisksVolume.h
@@ -63,7 +63,7 @@
 @property (readonly) NXTFSType filesystemType;
 @property (readonly) NSString *filesystemName;
 @property (readonly) NSString *label;
-@property (readonly) NSArray *mountPoints;
+@property (readonly) NSString *mountPoint;
 @property (readonly) BOOL isMounted;
 @property (readonly) BOOL isWritable;
 

--- a/Frameworks/SystemKit/OSEUDisksVolume.m
+++ b/Frameworks/SystemKit/OSEUDisksVolume.m
@@ -61,6 +61,10 @@
 //-------------------------------------------------------------------------------
 - (void)dealloc
 {
+  [_udisksAdaptor.connection removeSignalObserver:self
+                                           signal:@"PropertiesChanged"
+                                           object:self.objectPath
+                                        interface:@"org.freedesktop.DBus.Properties"];
   [_properties release];
   [_objectPath release];
 
@@ -86,8 +90,7 @@
                                       selector:@selector(handlePropertiesChangedSignal:)
                                         signal:@"PropertiesChanged"
                                         object:self.objectPath
-                                     interface:@"org.freedesktop.DBus.Properties"
-                                  notification:OSEUDisksPropertiesDidChangeNotification];
+                                     interface:@"org.freedesktop.DBus.Properties"];
   
   // [self _dumpProperties];
 

--- a/Frameworks/SystemKit/OSEUDisksVolume.m
+++ b/Frameworks/SystemKit/OSEUDisksVolume.m
@@ -145,6 +145,7 @@
 {
   NSDebugLLog(@"dealloc", @"OSEUDisksVolume -dealloc %@", self.objectPath);
 
+  [self removeSignalsObserving];
   [_properties release];
   [_objectPath release];
 

--- a/Frameworks/SystemKit/OSEUDisksVolume.m
+++ b/Frameworks/SystemKit/OSEUDisksVolume.m
@@ -463,8 +463,6 @@
                 signature:@"a{sv}"];
   if (wait) {
     result = [busMessage sendWithConnection:_udisksAdaptor.connection];
-    [busMessage release];
-
     NSDebugLLog(@"UDisks", @"OSEUDisksVolume -mount result: %@", result);
     if ([result isKindOfClass:[NSError class]]) {
       message = [(NSError *)result userInfo][@"Description"];
@@ -484,6 +482,7 @@
                                   title:@"Mount"
                                 message:message];
     }
+  [busMessage release];
   } else {
     [busMessage sendAsyncWithConnection:_udisksAdaptor.connection];
     message = @"Asynchronous volume mounting has been called!";
@@ -494,6 +493,7 @@
                                status:@"Completed"
                                 title:@"Mount"
                               message:message];
+    // `busMessage` should not be released here beacuse of async operation.
   }
 
   return result;
@@ -526,10 +526,9 @@
                    method:@"Unmount"
                 arguments:@[ @[ @{@"auth.no_user_interaction" : @"b:true"} ] ]
                 signature:@"a{sv}"];
-  
+
   if (wait) {
     result = [busMessage sendWithConnection:_udisksAdaptor.connection];
-    [busMessage release];
     NSDebugLLog(@"UDisks", @"OSEUDisksVolume -unmount result: %@", result);
     if ([result isKindOfClass:[NSError class]]) {
       message = [(NSError *)result userInfo][@"Description"];
@@ -550,8 +549,10 @@
                                 message:message];
       return YES;
     }
+    [busMessage release];
   } else {
-    message = @"Asynchronous volume unmounting is not implemented!";
+    [busMessage sendAsyncWithConnection:_udisksAdaptor.connection];
+    message = @"Asynchronous volume un-mounting has been called!";
     NSDebugLLog(@"UDisks", @"Warning: %@", message);
     [_udisksAdaptor operationWithName:@"Unmount"
                                object:self
@@ -559,6 +560,7 @@
                                status:@"Completed"
                                 title:@"Unmount"
                               message:message];
+    // `busMessage` should not be released here beacuse of async operation.
     return YES;
   }
 

--- a/Frameworks/SystemKit/OSEUDisksVolume.m
+++ b/Frameworks/SystemKit/OSEUDisksVolume.m
@@ -180,10 +180,13 @@
 
 - (void)removeSignalsObserving
 {
-  [_udisksAdaptor.connection removeSignalObserver:self
-                                           signal:@"PropertiesChanged"
-                                           object:self.objectPath
-                                        interface:@"org.freedesktop.DBus.Properties"];
+  // UDisksAdaptor could be deallocated first
+  if (_udisksAdaptor) {
+    [_udisksAdaptor.connection removeSignalObserver:self
+                                             signal:@"PropertiesChanged"
+                                             object:self.objectPath
+                                          interface:@"org.freedesktop.DBus.Properties"];
+  }
 }
 
 // Change _properties
@@ -483,7 +486,7 @@
                                   title:@"Mount"
                                 message:message];
     }
-  [busMessage release];
+    [busMessage release];
   } else {
     [busMessage sendAsyncWithConnection:_udisksAdaptor.connection];
     message = @"Asynchronous volume mounting has been called!";

--- a/Frameworks/SystemKit/OSEUDisksVolume.m
+++ b/Frameworks/SystemKit/OSEUDisksVolume.m
@@ -123,7 +123,7 @@
             [[NSNotificationCenter defaultCenter]
                 postNotificationName:OSEMediaVolumeDidUnmountNotification
                               object:_udisksAdaptor
-                            userInfo:@{@"MountPoint" : [self mountPoints].firstObject}];
+                            userInfo:@{}];
           }
         }
       }

--- a/Frameworks/SystemKit/OSEUDisksVolume.m
+++ b/Frameworks/SystemKit/OSEUDisksVolume.m
@@ -467,7 +467,7 @@
                 signature:@"a{sv}"];
   if (wait) {
     result = [busMessage sendWithConnection:_udisksAdaptor.connection];
-    NSDebugLLog(@"UDisks", @"OSEUDisksVolume -mount result: %@", result);
+    NSDebugLLog(@"UDisks", @"OSEUDisksVolume -mount %@ result: %@", _objectPath, result);
     if ([result isKindOfClass:[NSError class]]) {
       message = [(NSError *)result userInfo][@"Description"];
       [_udisksAdaptor operationWithName:@"Mount"
@@ -513,7 +513,7 @@
     return NO;
   }
 
-  NSDebugLLog(@"UDisks", @"OSEOSEUDisksVolume: unmount: %@", _objectPath);
+  NSDebugLLog(@"UDisks", @"OSEUDisksVolume: unmount: %@", _objectPath);
 
   message = [NSString stringWithFormat:@"Unmounting volume %@", [self UNIXDevice]];
   [_udisksAdaptor operationWithName:@"Unmount"
@@ -533,7 +533,7 @@
 
   if (wait) {
     result = [busMessage sendWithConnection:_udisksAdaptor.connection];
-    NSDebugLLog(@"UDisks", @"OSEUDisksVolume -unmount result: %@", result);
+    NSDebugLLog(@"UDisks", @"OSEUDisksVolume -unmount %@ result: %@", _objectPath, result);
     if ([result isKindOfClass:[NSError class]]) {
       message = [(NSError *)result userInfo][@"Description"];
       [_udisksAdaptor operationWithName:@"Unmount"

--- a/Frameworks/SystemKit/OSEUDisksVolume.m
+++ b/Frameworks/SystemKit/OSEUDisksVolume.m
@@ -61,6 +61,7 @@
 //-------------------------------------------------------------------------------
 - (void)dealloc
 {
+  NSDebugLLog(@"dealloc", @"OSEUDisksVolume -dealloc %@", self.objectPath);
   [_udisksAdaptor.connection removeSignalObserver:self
                                            signal:@"PropertiesChanged"
                                            object:self.objectPath

--- a/Frameworks/SystemKit/OSEUDisksVolume.m
+++ b/Frameworks/SystemKit/OSEUDisksVolume.m
@@ -19,9 +19,7 @@
 // Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111 USA.
 //
 
-#ifdef WITH_UDISKS
-
-#import <udisks/udisks.h>
+#import <SystemKit/OSEBusMessage.h>
 
 #import "OSEUDisksDrive.h"
 #import "OSEUDisksVolume.h"
@@ -31,183 +29,139 @@
 - (void)_dumpProperties
 {
   NSString *fileName;
-  NSMutableDictionary *props = [properties mutableCopy];
-  
-  fileName = [NSString stringWithFormat:@"Library/Workspace/Volume_%@",
-                       [objectPath lastPathComponent]];
-  if (drive)
-    {
-      [props setObject:drive forKey:@"_DriveObject"];
-    }
+  NSMutableDictionary *props = [_properties mutableCopy];
+
+  fileName = [NSString stringWithFormat:@"_Volume_%@", [_objectPath lastPathComponent]];
   [props writeToFile:fileName atomically:YES];
   [props release];
 }
 
-//-------------------------------------------------------------------------------
-//--- UDisksMedia protocol
-//-------------------------------------------------------------------------------
-- (id)initWithProperties:(NSDictionary *)props
-              objectPath:(NSString *)path
-                 adaptor:(OSEUDisksAdaptor *)udisksAdaptor
+- (void)handlePropertiesChangedSignal:(NSNotification *)aNotif
 {
-  self = [super init];
-
-  adaptor = udisksAdaptor;
-  
-  properties = [props mutableCopy];
-  objectPath = [path copy];
-  
-  notificationCenter = [NSNotificationCenter defaultCenter];
-
-  OSEUDisksDrive *d;
-  if ((d = [[adaptor availableDrives] objectForKey:[self driveObjectPath]]) != nil)
-    {
-      [self setDrive:d];
-      [drive addVolume:self withPath:objectPath];
-    }
-
-  // [self _dumpProperties];
-  
-  return self;
+  NSLog(@"OSEUDisksAdaptor Volume \e[1mPropertiesChanged\e[0m: %@", aNotif.userInfo[@"Message"]);
 }
 
+//-------------------------------------------------------------------------------
+#pragma mark - UDisksObject protocol
+//-------------------------------------------------------------------------------
 - (void)dealloc
 {
-  [properties release];
-  [objectPath release];
-  
-  TEST_RELEASE(drive);
-  
+  [_properties release];
+  [_objectPath release];
+
+  // No need to release '_udisksAdaptor' and '_drive' they are declared as 'assign'
+  // properties and will be released by @autoreleasepool {}
+
   [super dealloc];
 }
 
-// Change properties
-- (void)setProperty:(NSString *)property
-              value:(NSString *)value
-      interfaceName:(NSString *)interface
+- (id)initWithProperties:(NSDictionary *)properties objectPath:(NSString *)path
+{
+  self = [super init];
+
+  _properties = [properties mutableCopy];
+  _objectPath = [path copy];
+
+  notificationCenter = [NSNotificationCenter defaultCenter];
+
+  [_udisksAdaptor.connection addSignalObserver:self
+                                      selector:@selector(handlePropertiesChangedSignal:)
+                                        signal:@"PropertiesChanged"
+                                        object:self.objectPath
+                                     interface:@"org.freedesktop.DBus.Properties"
+                                  notification:OSEUDisksPropertiesDidChangeNotification];
+
+  // [self _dumpProperties];
+
+  return self;
+}
+
+// Change _properties
+- (void)setProperty:(NSString *)property value:(NSString *)value interfaceName:(NSString *)interface
 {
   NSMutableDictionary *interfaceDict;
-  NSMutableDictionary *info;
 
   // Get dictionary which contains changed property
-  if (!(interfaceDict = [[properties objectForKey:interface] mutableCopy]))
-    {
-      interfaceDict = [NSMutableDictionary new];
-    }
-  else if ([[interfaceDict objectForKey:property] isEqualToString:value])
-    {
-      // Protect from generating actions on double-setting properties
-      return;
-    }
-  
-  if ([property isEqualToString:@"MountPoints"] &&
-      [interfaceDict objectForKey:@"MountPoints"])
-    {
-      [interfaceDict setObject:[interfaceDict objectForKey:@"MountPoints"]
-                        forKey:@"OldMountPoint"];
-    }
-  
+  if (!(interfaceDict = [[_properties objectForKey:interface] mutableCopy])) {
+    interfaceDict = [NSMutableDictionary new];
+  } else if ([[interfaceDict objectForKey:property] isEqualToString:value]) {
+    // Protect from generating actions on double-setting _properties
+    return;
+  }
+
+  if ([property isEqualToString:@"MountPoints"] && [interfaceDict objectForKey:@"MountPoints"]) {
+    [interfaceDict setObject:[interfaceDict objectForKey:@"MountPoints"] forKey:@"OldMountPoint"];
+  }
+
   // Update property
-  if (value)
-    {
-      [interfaceDict setObject:value forKey:property];
-    }
-  [properties setObject:interfaceDict forKey:interface];
+  if (value) {
+    [interfaceDict setObject:value forKey:property];
+  }
+  [_properties setObject:interfaceDict forKey:interface];
   [interfaceDict release];
 
   // Mounted state of volume changed
-  if ([property isEqualToString:@"MountPoints"])
-    {
-      if ([value isEqualToString:@""])
-        {
-          [adaptor operationWithName:@"Unmount"
-                              object:self
-                              failed:NO
-                              status:@"Occured"
-                               title:@"Unmount"
-                             message:@"Volume unmounted at system level."];
-        }
-      else
-        {
-          [adaptor operationWithName:@"Mount"
-                              object:self
-                              failed:NO
-                              status:@"Occured"
-                               title:@"Mount"
-                             message:@"Volume mounted at system level."];
-        }
+  if ([property isEqualToString:@"MountPoints"]) {
+    if ([value isEqualToString:@""]) {
+      [_udisksAdaptor operationWithName:@"Unmount"
+                                 object:self
+                                 failed:NO
+                                 status:@"Occured"
+                                  title:@"Unmount"
+                                message:@"Volume unmounted at system level."];
+    } else {
+      [_udisksAdaptor operationWithName:@"Mount"
+                                 object:self
+                                 failed:NO
+                                 status:@"Occured"
+                                  title:@"Mount"
+                                message:@"Volume mounted at system level."];
     }
+  }
 
-  // Optical drive gets media or block device was formatted.
-  if ([property isEqualToString:@"IdUsage"] &&
-      [value isEqualToString:@"filesystem"])
-    {
-      [self mount:NO];
-    }
+  // Optical _drive gets media or block device was formatted.
+  if ([property isEqualToString:@"IdUsage"] && [value isEqualToString:@"filesystem"]) {
+    [self mount:NO];
+  }
 
   // [self _dumpProperties];
 }
 
-- (void)removeProperties:(NSArray *)props
-           interfaceName:(NSString *)interface
+- (void)removeProperties:(NSArray *)props interfaceName:(NSString *)interface
 {
-  NSDebugLLog(@"udisks", @"Volume: remove properties: %@ for interface: %@",
-        props, interface);
-}
-
-// Access to properties
-- (NSDictionary *)properties
-{
-  return properties;
+  NSDebugLLog(@"udisks", @"Volume: remove _properties: %@ for interface: %@", props, interface);
 }
 
 - (NSString *)propertyForKey:(NSString *)key interface:(NSString *)interface
 {
   NSDictionary *interfaceDict;
-  NSString     *value;
+  NSString *value;
 
-  if (interface)
-    {
-      interfaceDict = [properties objectForKey:interface];
-      value = [interfaceDict objectForKey:key];
-    }
-  else
-    {
-      value = [properties objectForKey:key];
-    }
+  if (interface) {
+    interfaceDict = [_properties objectForKey:interface];
+    value = [interfaceDict objectForKey:key];
+  } else {
+    value = [_properties objectForKey:key];
+  }
 
   return value;
 }
 
 - (BOOL)boolPropertyForKey:(NSString *)key interface:(NSString *)interface
 {
-  if ([[self propertyForKey:key interface:interface] isEqualToString:@"true"])
-    return YES;
-  else
-    return NO;
-}
+  id propertyValue = [self propertyForKey:key interface:interface];
+  BOOL boolValue = NO;
 
+  if ([propertyValue isKindOfClass:[NSNumber class]]) {
+    boolValue = [propertyValue boolValue];
+  }
+  return boolValue;
+}
 
 //-------------------------------------------------------------------------------
-//--- Parent object
+#pragma mark - Parent objects
 //-------------------------------------------------------------------------------
-- (OSEUDisksAdaptor *)adaptor
-{
-  return adaptor;
-}
-
-- (OSEUDisksDrive *)drive
-{
-  return drive;
-}
-
-- (void)setDrive:(OSEUDisksDrive *)driveObject
-{
-  ASSIGN(drive, driveObject);
-  // [self _dumpProperties];
-}
-
-// Master volume represents drive partition table e.g. '/dev/sda'.
+// Master volume represents _drive partition table e.g. '/dev/sda'.
 - (OSEUDisksVolume *)masterVolume
 {
   NSString *masterPath;
@@ -216,13 +170,8 @@
 
   if (!masterPath)
     return nil;
-  
-  return [adaptor _objectWithUDisksPath:[masterPath cString]];
-}
 
-- (NSString *)objectPath
-{
-  return objectPath;
+  return [_udisksAdaptor objectWithUDisksPath:masterPath];
 }
 
 - (NSString *)driveObjectPath
@@ -231,9 +180,75 @@
 }
 
 //-------------------------------------------------------------------------------
-//--- General properties
+#pragma mark - General properties
 //-------------------------------------------------------------------------------
-- (NXTFSType)type
+- (NSString *)UUID
+{
+  return [self propertyForKey:@"IdUUID" interface:BLOCK_INTERFACE];
+}
+
+- (NSString *)UNIXDevice
+{
+  return [self propertyForKey:@"Device" interface:BLOCK_INTERFACE];
+}
+
+- (NSNumber *)size
+{
+  return [self propertyForKey:@"Size" interface:BLOCK_INTERFACE];
+}
+
+- (BOOL)isSystem
+{
+  if ([self boolPropertyForKey:@"HintSystem" interface:BLOCK_INTERFACE] && ![self isLoopVolume] &&
+      [self masterVolume] != self &&
+      ![self boolPropertyForKey:@"HintAuto" interface:BLOCK_INTERFACE]) {
+    return YES;
+  }
+
+  return NO;
+}
+
+// Partition
+- (BOOL)hasPartition
+{
+  NSDictionary *interfaceDict = [_properties objectForKey:PARTITION_INTERFACE];
+  if (interfaceDict != nil && interfaceDict.allKeys.count > 0) {
+    return YES;
+  }
+  return NO;
+}
+- (NSString *)partitionType
+{
+  return [self propertyForKey:@"Type" interface:PARTITION_INTERFACE];
+}
+
+- (NSNumber *)partitionNumber
+{
+  return [self propertyForKey:@"Number" interface:PARTITION_INTERFACE];
+}
+
+- (NSNumber *)partitionSize
+{
+  return [self propertyForKey:@"Size" interface:PARTITION_INTERFACE];
+}
+
+// Filesystem
+- (BOOL)isFilesystem
+{
+  NSString *usage = [self propertyForKey:@"IdUsage" interface:BLOCK_INTERFACE];
+  // BOOL isFilesystem = [usage isEqualToString:@"filesystem"];
+  BOOL isFilesystem = NO;
+
+  // NSLog(@"isFilesystem: %@ = %@", _objectPath, [_properties objectForKey:FS_INTERFACE]);
+
+  if (([_properties objectForKey:FS_INTERFACE] != nil) || ([usage isEqualToString:@"filesystem"] != NO)) {
+    isFilesystem = YES;
+  }
+
+  return isFilesystem;
+}
+
+- (NXTFSType)filesystemType
 {
   NSString *fsType = [self propertyForKey:@"IdType" interface:BLOCK_INTERFACE];
 
@@ -261,9 +276,14 @@
   return -1;
 }
 
-- (NSString *)UUID
+- (NSString *)filesystemName
 {
-  return [self propertyForKey:@"IdUUID" interface:BLOCK_INTERFACE];
+  NSString *name = [self propertyForKey:@"IdType" interface:BLOCK_INTERFACE];
+
+  if (name == nil || [name isEqualToString:@""]) {
+    return @"Unknown";
+  }
+  return name;
 }
 
 - (NSString *)label
@@ -271,62 +291,19 @@
   return [self propertyForKey:@"IdLabel" interface:BLOCK_INTERFACE];
 }
 
-- (NSString *)size
-{
-  return [self propertyForKey:@"Size" interface:BLOCK_INTERFACE];
-}
-
-- (NSString *)UNIXDevice
-{
-  return [self propertyForKey:@"Device" interface:BLOCK_INTERFACE];
-}
-
-- (NSString *)mountPoints
+- (NSArray *)mountPoints
 {
   return [self propertyForKey:@"MountPoints" interface:FS_INTERFACE];
 }
 
-// Partition table
-- (NSString *)partitionType
-{
-  return [self propertyForKey:@"Type" interface:PARTITION_INTERFACE];
-}
-
-- (NSString *)partitionNumber
-{
-  return [self propertyForKey:@"Number" interface:PARTITION_INTERFACE];
-}
-
-- (NSString *)partitionSize
-{
-  return [self propertyForKey:@"Size" interface:PARTITION_INTERFACE];
-}
-
-// Extented
-- (BOOL)isFilesystem
-{
-  NSString *usage = [self propertyForKey:@"IdUsage" interface:BLOCK_INTERFACE];
-  BOOL     isFilesystem = [usage isEqualToString:@"filesystem"];
-
-  // NSLog(@"isFilesystem: %@ = %@", objectPath, [properties objectForKey:FS_INTERFACE]);
-  
-  if ([properties objectForKey:FS_INTERFACE] == nil)
-    {
-      isFilesystem = NO;
-    }
-  
-  return isFilesystem;
-}
-
 - (BOOL)isMounted
 {
+  NSArray *mountPoints = [self mountPoints];
+
   // Don't call [self isFilesystem] because CD has IdUsage=""
-  // if (![self isFilesystem] ||
-  if (![self mountPoints] ||
-      [[self mountPoints] isEqualToString:@""])
-    {
-      return NO;
-    }
+  if (mountPoints == nil || mountPoints.count == 0 || [mountPoints[0] isEqualToString:@""]) {
+    return NO;
+  }
 
   return YES;
 }
@@ -336,253 +313,133 @@
   return ![self boolPropertyForKey:@"ReadOnly" interface:BLOCK_INTERFACE];
 }
 
-// OSEUDisksVolume which represents mapped image file
+// OSEOSEUDisksVolume which represents mapped image file
 - (BOOL)isLoopVolume
 {
-  NSString *drivePath = [self propertyForKey:@"Drive" interface:BLOCK_INTERFACE];
+  NSString *_drivePath = [self propertyForKey:@"Drive" interface:BLOCK_INTERFACE];
 
-  return [drivePath isEqualToString:@"/"];
+  return [_drivePath isEqualToString:@"/"];
 }
 
-- (BOOL)isSystem
-{
-  if ([self boolPropertyForKey:@"HintSystem" interface:BLOCK_INTERFACE] &&
-      ![self isLoopVolume] && [self masterVolume] != self &&
-      ![self boolPropertyForKey:@"HintAuto" interface:BLOCK_INTERFACE])
-    {
-      return YES;
-    }
-      
-  return NO;
-}
-
-//--- Actions
-
-// Callback for async mount operation
-static void mount_callback(UDisksFilesystem *filesystem,
-                           GAsyncResult *res,
-                           OSEUDisksVolume *volume)
-{
-  GError *error = NULL;
-  gchar *mount_point;
-  OSEUDisksAdaptor *adaptor = [volume adaptor];
-  
-  udisks_filesystem_call_mount_finish(filesystem, &mount_point, res, &error);
-  
-  if (error != NULL && error->code != 0)
-    {
-      NSLog(@"[OSEUDisksVolume mount_callback()] error: %i message: %@",
-            error->code, [adaptor descriptionForError:error]);
-      [adaptor operationWithName:@"Mount"
-                          object:volume
-                          failed:YES
-                          status:@"Completed"
-                           title:@"Mount error"
-                         message:[adaptor descriptionForError:error]];
-    }
-  else
-    {
-      NSString *message;
-      message = [NSString stringWithFormat:@"Mount of %@ completed at mount point %s",
-                          [volume UNIXDevice], mount_point];
-
-      // TODO: do not generate extra notifications
-      [volume setProperty:@"MountPoints"
-                    value:[[NSString stringWithCString:mount_point] stringByResolvingSymlinksInPath]
-            interfaceName:FS_INTERFACE];
-      
-      [adaptor operationWithName:@"Mount"
-                          object:volume
-                          failed:NO
-                          status:@"Completed"
-                           title:@"Mount"
-                         message:message];
-    }
-}
+//-------------------------------------------------------------------------------
+#pragma mark - Actions
+//-------------------------------------------------------------------------------
 
 - (NSString *)mount:(BOOL)wait
 {
-  UDisksObject     *ud_object;
-  UDisksFilesystem *ud_filesystem;
-  gchar            *ud_mount_point;
-  gboolean          ud_result = 0;
-  GError           *error = NULL;
-  NSString         *message;
+  NSString *message;
+  OSEBusMessage *busMessage;
+  id result = nil;
 
-  if (![self isFilesystem] || [self isMounted] || [self isSystem])
-    {
-      return nil;
-    }
+  if (!self.isFilesystem || self.isMounted || self.isSystem) {
+    return nil;
+  }
 
-  ud_object = udisks_client_get_object([adaptor udisksClient], [objectPath cString]);
-  ud_filesystem = udisks_object_peek_filesystem(ud_object);
-
-  NSDebugLLog(@"udisks", @"OSEUDisksVolume: mountVolume: %@", objectPath);
+  NSDebugLLog(@"udisks", @"OSEOSEUDisksVolume: mountVolume: %@", _objectPath);
+  NSLog(@"OSEOSEUDisksVolume: mount: %@", _objectPath);
 
   message = [NSString stringWithFormat:@"Mounting volume %@", [self UNIXDevice]];
-  [adaptor operationWithName:@"Mount"
-                      object:self
-                      failed:NO
-                      status:@"Started"
-                       title:@"Mount"
-                     message:message];
-  if (wait)
-    {
-      // GVariantBuilder *options = g_variant_builder_new(G_VARIANT_TYPE("a{sv}"));
-      // g_variant_builder_add(options, "{sv}",
-      //                       "options", g_variant_new_string("ro"));
- 
-      ud_result = udisks_filesystem_call_mount_sync(ud_filesystem,
-                                                    g_variant_new("a{sv}", NULL),
-                                                    &ud_mount_point,    // gchar **
-                                                    NULL,               // GCancellable *
-                                                    &error);            // GError **
-      if (error != NULL && error->code != 0)
-        {
-          [adaptor operationWithName:@"Mount"
-                              object:self
-                              failed:YES
-                              status:@"Completed"
-                               title:@"Mount"
-                             message:[adaptor descriptionForError:error]];
-        }
-      else
-        {
-          message = [NSString stringWithFormat:@"Mount of %@ completed at mount point %s",
-                              [self UNIXDevice], ud_mount_point];
-          [adaptor operationWithName:@"Mount"
-                              object:self
-                              failed:NO
-                              status:@"Completed"
-                               title:@"Mount"
-                             message:message];
-        }
+  [_udisksAdaptor operationWithName:@"Mount"
+                             object:self
+                             failed:NO
+                             status:@"Started"
+                              title:@"Mount"
+                            message:message];
+
+  if (wait) {
+    busMessage = [[OSEBusMessage alloc]
+        initWithServiceName:_udisksAdaptor.serviceName
+                     object:_objectPath
+                  interface:FS_INTERFACE
+                     method:@"Mount"
+                  arguments:@[ @[ @{@"auth.no_user_interaction" : @"b:true"} ] ]
+                  signature:@"a{sv}"];
+    result = [busMessage sendWithConnection:_udisksAdaptor.connection];
+    [busMessage release];
+
+    NSLog(@"OSEUDisksVolume -mount result: %@", result);
+    if ([result isKindOfClass:[NSError class]]) {
+      message = [(NSError *)result userInfo][@"Description"];
+      [_udisksAdaptor operationWithName:@"Mount"
+                                 object:self
+                                 failed:YES
+                                 status:@"Completed"
+                                  title:@"Mount"
+                                message:message];
+    } else {
+      message = [NSString
+          stringWithFormat:@"Mount of %@ completed at mount point %@", [self UNIXDevice], result];
+      [_udisksAdaptor operationWithName:@"Mount"
+                                 object:self
+                                 failed:NO
+                                 status:@"Completed"
+                                  title:@"Mount"
+                                message:message];
     }
-  else
-    {
+  } else {
+    NSLog(@"Warning: Asynchronous volume mounting is not implemented!");
+  }
 
-      udisks_filesystem_call_mount(ud_filesystem,
-                                   g_variant_new("a{sv}", NULL),
-                                   NULL,                   // GCancellable *
-                                   (GAsyncReadyCallback)mount_callback,
-                                   self);               // gpointer user_data
-      // [adaptor operationWithName:] will be sent in mount_callback()
-    }
-  
-  g_object_unref(ud_object);
-
-  if (ud_result)
-    return [NSString stringWithCString:ud_mount_point];
-  else
-    return nil;
-}
-
-// Callback for async mount operation
-static void unmount_callback(UDisksFilesystem *filesystem,
-                             GAsyncResult *res,
-                             OSEUDisksVolume *volume)
-{
-  GError *error = NULL;
-  OSEUDisksAdaptor *adaptor = [volume adaptor];
-
-  udisks_filesystem_call_unmount_finish(filesystem, res, &error);
-
-  if (error != NULL && error->code != 0)
-    {
-      NSLog(@"[OSEUDisksVolume unmount_callback()] error: %i message: %@",
-            error->code, [adaptor descriptionForError:error]);
-      [adaptor operationWithName:@"Unmount"
-                          object:volume
-                          failed:YES
-                          status:@"Completed"
-                           title:@"Unmount error"
-                         message:[adaptor descriptionForError:error]];
-    }
-  else
-    {
-      NSString *message;
-      message = [NSString stringWithFormat:@"Unmount of %@ completed successfully.",
-                          [volume UNIXDevice]];
-      [adaptor operationWithName:@"Unmount"
-                          object:volume
-                          failed:NO
-                          status:@"Completed"
-                           title:@"Unmount"
-                         message:message];
-    }
+  return nil;
 }
 
 - (BOOL)unmount:(BOOL)wait
 {
-  UDisksObject     *ud_object;
-  UDisksFilesystem *ud_filesystem;
-  gboolean          ud_result = 0;
-  GError           *error = NULL;
-  NSString         *message;
+  NSString *message;
+  OSEBusMessage *busMessage;
+  id result = nil;
 
-  if (![self isFilesystem] || ![self isMounted])
-    {
+  if (!self.isFilesystem || !self.isMounted || self.isSystem) {
+    return NO;
+  }
+
+  NSDebugLLog(@"udisks", @"OSEOSEUDisksVolume: unmount: %@", _objectPath);
+  NSLog(@"OSEOSEUDisksVolume: unmount: %@", _objectPath);
+
+  message = [NSString stringWithFormat:@"Unmounting volume %@", [self UNIXDevice]];
+  [_udisksAdaptor operationWithName:@"Unmount"
+                             object:self
+                             failed:NO
+                             status:@"Started"
+                              title:@"Unmount"
+                            message:message];
+
+  if (wait) {
+    busMessage = [[OSEBusMessage alloc]
+        initWithServiceName:_udisksAdaptor.serviceName
+                     object:_objectPath
+                  interface:FS_INTERFACE
+                     method:@"Unmount"
+                  arguments:@[ @[ @{@"auth.no_user_interaction" : @"b:true"} ] ]
+                  signature:@"a{sv}"];
+    result = [busMessage sendWithConnection:_udisksAdaptor.connection];
+    [busMessage release];
+
+    NSLog(@"OSEUDisksVolume -unmount result: %@", result);
+    if ([result isKindOfClass:[NSError class]]) {
+      message = [(NSError *)result userInfo][@"Description"];
+      [_udisksAdaptor operationWithName:@"Unmount"
+                                 object:self
+                                 failed:YES
+                                 status:@"Completed"
+                                  title:@"Unmount"
+                                message:message];
+    } else {
+      message =
+          [NSString stringWithFormat:@"Unmount of %@ completed successfully.", [self UNIXDevice]];
+      [_udisksAdaptor operationWithName:@"Unmount"
+                                 object:self
+                                 failed:NO
+                                 status:@"Completed"
+                                  title:@"Unmount"
+                                message:message];
       return YES;
     }
+  } else {
+    NSLog(@"Warning: Asynchronous volume unmounting is not implemented!");
+  }
 
-  ud_object = udisks_client_get_object([adaptor udisksClient],
-                                       [objectPath cString]);
-  ud_filesystem = udisks_object_peek_filesystem(ud_object);
-
-  NSDebugLLog(@"udisks", @"OSEUDisksVolume: unMountVolume: %@", objectPath);
-
-  message = [NSString stringWithFormat:@"Unmounting volume %@",
-                      [self UNIXDevice]];
-  [adaptor operationWithName:@"Unmount"
-                      object:self
-                      failed:NO
-                      status:@"Started"
-                       title:@"Unmount"
-                     message:message];
-  if (wait)
-    {
-      ud_result =
-        udisks_filesystem_call_unmount_sync(ud_filesystem,
-                                            g_variant_new("a{sv}", NULL),
-                                            NULL,   // GCancellable *
-                                            &error);  // GError **
-      if (error != NULL && error->code != 0)
-        {
-          [adaptor operationWithName:@"Unmount"
-                              object:self
-                              failed:YES
-                              status:@"Completed"
-                               title:@"Unmount"
-                             message:[adaptor descriptionForError:error]];
-        }
-      else
-        {
-          message = [NSString
-                      stringWithFormat:@"Unmount of %@ completed successfully.",
-                      [self UNIXDevice]];
-          [adaptor operationWithName:@"Unmount"
-                              object:self
-                              failed:NO
-                              status:@"Completed"
-                               title:@"Unmount"
-                             message:message];
-        }
-    }
-  else
-    {
-      udisks_filesystem_call_unmount(ud_filesystem,
-                                     g_variant_new("a{sv}", NULL),
-                                     NULL,             // GCancellable *
-                                     (GAsyncReadyCallback)unmount_callback,
-                                     self);            // gpointer user_data
-      // [adaptor operationWithName:] will be sent in mount_callback()
-    }
-  
-  g_object_unref(ud_object);
-
-  return ud_result;
+  return NO;
 }
 
 @end
-
-#endif // WITH_UDISKS

--- a/Frameworks/SystemKit/OSEUDisksVolume.m
+++ b/Frameworks/SystemKit/OSEUDisksVolume.m
@@ -38,7 +38,8 @@
 
 - (void)handlePropertiesChangedSignal:(NSNotification *)aNotif
 {
-  NSLog(@"OSEUDisksAdaptor Volume \e[1mPropertiesChanged\e[0m: %@", aNotif.userInfo[@"Message"]);
+  NSDebugLLog(@"UDisks", @"OSEUDisksAdaptor Volume \e[1mPropertiesChanged\e[0m: %@",
+             aNotif.userInfo[@"Message"]);
 }
 
 //-------------------------------------------------------------------------------
@@ -239,7 +240,7 @@
   // BOOL isFilesystem = [usage isEqualToString:@"filesystem"];
   BOOL isFilesystem = NO;
 
-  // NSLog(@"isFilesystem: %@ = %@", _objectPath, [_properties objectForKey:FS_INTERFACE]);
+  // NSDebugLLog(@"UDisks", @"isFilesystem: %@ = %@", _objectPath, [_properties objectForKey:FS_INTERFACE]);
 
   if (([_properties objectForKey:FS_INTERFACE] != nil) || ([usage isEqualToString:@"filesystem"] != NO)) {
     isFilesystem = YES;
@@ -335,8 +336,7 @@
     return nil;
   }
 
-  NSDebugLLog(@"udisks", @"OSEOSEUDisksVolume: mountVolume: %@", _objectPath);
-  NSLog(@"OSEOSEUDisksVolume: mount: %@", _objectPath);
+  NSDebugLLog(@"UDisks", @"OSEOSEUDisksVolume: mount: %@", _objectPath);
 
   message = [NSString stringWithFormat:@"Mounting volume %@", [self UNIXDevice]];
   [_udisksAdaptor operationWithName:@"Mount"
@@ -345,7 +345,7 @@
                              status:@"Started"
                               title:@"Mount"
                             message:message];
-
+    
   if (wait) {
     busMessage = [[OSEBusMessage alloc]
         initWithServiceName:_udisksAdaptor.serviceName
@@ -357,7 +357,7 @@
     result = [busMessage sendWithConnection:_udisksAdaptor.connection];
     [busMessage release];
 
-    NSLog(@"OSEUDisksVolume -mount result: %@", result);
+    NSDebugLLog(@"UDisks", @"OSEUDisksVolume -mount result: %@", result);
     if ([result isKindOfClass:[NSError class]]) {
       message = [(NSError *)result userInfo][@"Description"];
       [_udisksAdaptor operationWithName:@"Mount"
@@ -377,7 +377,14 @@
                                 message:message];
     }
   } else {
-    NSLog(@"Warning: Asynchronous volume mounting is not implemented!");
+    message = @"Asynchronous volume mounting is not implemented!";
+    NSDebugLLog(@"UDisks", @"Warning: %@", message);
+    [_udisksAdaptor operationWithName:@"Mount"
+                               object:self
+                               failed:NO
+                               status:@"Completed"
+                                title:@"Mount"
+                              message:message];
   }
 
   return nil;
@@ -393,8 +400,7 @@
     return NO;
   }
 
-  NSDebugLLog(@"udisks", @"OSEOSEUDisksVolume: unmount: %@", _objectPath);
-  NSLog(@"OSEOSEUDisksVolume: unmount: %@", _objectPath);
+  NSDebugLLog(@"UDisks", @"OSEOSEUDisksVolume: unmount: %@", _objectPath);
 
   message = [NSString stringWithFormat:@"Unmounting volume %@", [self UNIXDevice]];
   [_udisksAdaptor operationWithName:@"Unmount"
@@ -415,7 +421,7 @@
     result = [busMessage sendWithConnection:_udisksAdaptor.connection];
     [busMessage release];
 
-    NSLog(@"OSEUDisksVolume -unmount result: %@", result);
+    NSDebugLLog(@"UDisks", @"OSEUDisksVolume -unmount result: %@", result);
     if ([result isKindOfClass:[NSError class]]) {
       message = [(NSError *)result userInfo][@"Description"];
       [_udisksAdaptor operationWithName:@"Unmount"
@@ -436,8 +442,17 @@
       return YES;
     }
   } else {
-    NSLog(@"Warning: Asynchronous volume unmounting is not implemented!");
+    message = @"Asynchronous volume unmounting is not implemented!";
+    NSDebugLLog(@"UDisks", @"Warning: %@", message);
+    [_udisksAdaptor operationWithName:@"Unmount"
+                               object:self
+                               failed:NO
+                               status:@"Completed"
+                                title:@"Unmount"
+                              message:message];
+    return YES;
   }
+
 
   return NO;
 }

--- a/Frameworks/SystemKit/OSEUDisksVolume.m
+++ b/Frameworks/SystemKit/OSEUDisksVolume.m
@@ -38,8 +38,18 @@
 
 - (void)handlePropertiesChangedSignal:(NSNotification *)aNotif
 {
-  NSDebugLLog(@"UDisks", @"OSEUDisksAdaptor Volume \e[1mPropertiesChanged\e[0m: %@",
-             aNotif.userInfo[@"Message"]);
+  NSDictionary *info = aNotif.userInfo;
+  id objectPath = info[@"ObjectPath"];
+
+  if ([objectPath isKindOfClass:[NSString class]] && [objectPath isEqualToString:_objectPath] == NO) {
+    NSDebugLLog(@"UDisks",
+                @"OSEUDisksVolume (%@) \e[1mPropertiesChanged\e[0m: not mine, skipping...",
+                _objectPath);
+    return;
+  }
+
+  NSDebugLLog(@"UDisks", @"OSEUDisksVolume (%@) \e[1mPropertiesChanged\e[0m: %@", _objectPath,
+              aNotif.userInfo);
 }
 
 //-------------------------------------------------------------------------------
@@ -56,7 +66,9 @@
   [super dealloc];
 }
 
-- (id)initWithProperties:(NSDictionary *)properties objectPath:(NSString *)path
+- (id)initWithProperties:(NSDictionary *)properties
+              objectPath:(NSString *)path
+                 adaptor:(OSEUDisksAdaptor *)adaptor
 {
   self = [super init];
 
@@ -65,6 +77,7 @@
 
   notificationCenter = [NSNotificationCenter defaultCenter];
 
+  self.udisksAdaptor = adaptor;
   [_udisksAdaptor.connection addSignalObserver:self
                                       selector:@selector(handlePropertiesChangedSignal:)
                                         signal:@"PropertiesChanged"

--- a/Frameworks/SystemKit/OSEUDisksVolume.m
+++ b/Frameworks/SystemKit/OSEUDisksVolume.m
@@ -344,9 +344,9 @@
 // OSEOSEUDisksVolume which represents mapped image file
 - (BOOL)isLoopVolume
 {
-  NSString *_drivePath = [self propertyForKey:@"Drive" interface:BLOCK_INTERFACE];
+  NSArray *loopProperties = [_properties objectForKey:LOOP_INTERFACE];
 
-  return [_drivePath isEqualToString:@"/"];
+  return (loopProperties != nil || loopProperties.count > 0);
 }
 
 //-------------------------------------------------------------------------------

--- a/Frameworks/SystemKit/OSEUDisksVolume.m
+++ b/Frameworks/SystemKit/OSEUDisksVolume.m
@@ -20,6 +20,7 @@
 //
 
 #import <SystemKit/OSEBusMessage.h>
+#include "Foundation/NSArray.h"
 
 #import "OSEUDisksDrive.h"
 #import "OSEUDisksVolume.h"
@@ -408,17 +409,23 @@
   return [self propertyForKey:@"IdLabel" interface:BLOCK_INTERFACE];
 }
 
-- (NSArray *)mountPoints
+- (NSString *)mountPoint
 {
-  return [self propertyForKey:@"MountPoints" interface:FS_INTERFACE];
+  NSArray *points = [self propertyForKey:@"MountPoints" interface:FS_INTERFACE];
+
+  if (points && points.count > 0) {
+    return points.firstObject;
+  }
+
+  return nil;
 }
 
 - (BOOL)isMounted
 {
-  NSArray *mountPoints = [self mountPoints];
+  NSString *mountPoint = [self mountPoint];
 
   // Don't call [self isFilesystem] because CD has IdUsage=""
-  if (mountPoints == nil || mountPoints.count == 0 || [mountPoints[0] isEqualToString:@""]) {
+  if (mountPoint == nil || [mountPoint isEqualToString:@""]) {
     return NO;
   }
 

--- a/Frameworks/SystemKit/OSEUDisksVolume.m
+++ b/Frameworks/SystemKit/OSEUDisksVolume.m
@@ -36,12 +36,16 @@
   [props release];
 }
 
-- (void)handlePropertiesChangedSignal:(NSNotification *)aNotif
+- (void)handlePropertiesChangedSignal:(NSDictionary *)info
 {
-  NSDictionary *info = aNotif.userInfo;
   id objectPath = info[@"ObjectPath"];
+  // sa{sv}as
+  NSArray *message = info[@"Message"];
 
-  if ([objectPath isKindOfClass:[NSString class]] && [objectPath isEqualToString:_objectPath] == NO) {
+  NSLog(@"OSEUDisksVolume - handlePropertiesChanged");
+
+  if ([objectPath isKindOfClass:[NSString class]] &&
+      [objectPath isEqualToString:_objectPath] == NO) {
     NSDebugLLog(@"UDisks",
                 @"OSEUDisksVolume (%@) \e[1mPropertiesChanged\e[0m: not mine, skipping...",
                 _objectPath);
@@ -49,7 +53,7 @@
   }
 
   NSDebugLLog(@"UDisks", @"OSEUDisksVolume (%@) \e[1mPropertiesChanged\e[0m: %@", _objectPath,
-              aNotif.userInfo);
+              info);
 }
 
 //-------------------------------------------------------------------------------

--- a/Frameworks/SystemKit/OSEUDisksVolume.m
+++ b/Frameworks/SystemKit/OSEUDisksVolume.m
@@ -62,15 +62,10 @@
 - (void)dealloc
 {
   NSDebugLLog(@"dealloc", @"OSEUDisksVolume -dealloc %@", self.objectPath);
-  [_udisksAdaptor.connection removeSignalObserver:self
-                                           signal:@"PropertiesChanged"
-                                           object:self.objectPath
-                                        interface:@"org.freedesktop.DBus.Properties"];
+
+
   [_properties release];
   [_objectPath release];
-
-  // No need to release '_udisksAdaptor' and '_drive' they are declared as 'assign'
-  // properties and will be released by @autoreleasepool {}
 
   [super dealloc];
 }
@@ -84,18 +79,29 @@
   _properties = [properties mutableCopy];
   _objectPath = [path copy];
 
-  notificationCenter = [NSNotificationCenter defaultCenter];
-
   self.udisksAdaptor = adaptor;
+  [self setSignalsObserving];
+  
+  // [self _dumpProperties];
+
+  return self;
+}
+
+- (void)setSignalsObserving
+{
   [_udisksAdaptor.connection addSignalObserver:self
                                       selector:@selector(handlePropertiesChangedSignal:)
                                         signal:@"PropertiesChanged"
                                         object:self.objectPath
                                      interface:@"org.freedesktop.DBus.Properties"];
-  
-  // [self _dumpProperties];
+}
 
-  return self;
+- (void)removeSignalsObserving
+{
+  [_udisksAdaptor.connection removeSignalObserver:self
+                                           signal:@"PropertiesChanged"
+                                           object:self.objectPath
+                                        interface:@"org.freedesktop.DBus.Properties"];
 }
 
 // Change _properties
@@ -151,7 +157,7 @@
 
 - (void)removeProperties:(NSArray *)props interfaceName:(NSString *)interface
 {
-  NSDebugLLog(@"udisks", @"Volume: remove _properties: %@ for interface: %@", props, interface);
+  NSDebugLLog(@"UDisks", @"Volume: remove _properties: %@ for interface: %@", props, interface);
 }
 
 - (NSString *)propertyForKey:(NSString *)key interface:(NSString *)interface

--- a/Frameworks/SystemKit/OSEUDisksVolume.m
+++ b/Frameworks/SystemKit/OSEUDisksVolume.m
@@ -71,7 +71,7 @@
                                         object:self.objectPath
                                      interface:@"org.freedesktop.DBus.Properties"
                                   notification:OSEUDisksPropertiesDidChangeNotification];
-
+  
   // [self _dumpProperties];
 
   return self;

--- a/Frameworks/SystemKit/Tests/displaytool/displaytool_main.m
+++ b/Frameworks/SystemKit/Tests/displaytool/displaytool_main.m
@@ -195,54 +195,39 @@ void displayDetails(OSEDisplay *display)
 
 int main(int argc, char *argv[])
 {
-  NSAutoreleasePool	*pool = [NSAutoreleasePool new];
-  OSEScreen		*screen = [OSEScreen sharedScreen];
-  OSEDisplay		*display = nil;
-  BOOL			setMode, showDetails;
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+  OSEScreen *screen = [OSEScreen sharedScreen];
+  OSEDisplay *display = nil;
+  BOOL setMode, showDetails;
 
-  if (argc == 1)
-    {
-      screenInfo(screen);
-      listDisplays([screen activeDisplays], @"Active displays");
+  if (argc == 1) {
+    screenInfo(screen);
+    listDisplays([screen activeDisplays], @"Active displays");
+  }
+
+  for (int i = 1; i < argc; i++) {
+    if (argv[i][0] == '-') {
+      if (strcmp(argv[i], "-listAll") == 0) {
+        listDisplays([screen allDisplays], @"All registered displays");
+      } else if (strcmp(argv[i], "-listActive") == 0) {
+        listDisplays([screen activeDisplays], @"Active displays");
+      } else if (strcmp(argv[i], "-details") == 0 && (i + 1 < argc)) {
+        displayDetails([screen displayWithName:[NSString stringWithCString:argv[++i]]]);
+      } else if (strcmp(argv[i], "-display") == 0) {
+        display = [screen displayWithName:[NSString stringWithCString:argv[++i]]];
+      } else {
+        fprintf(stderr, "Unknown parameter specified: %s\n", argv[i]);
+      }
+    } else {
+      fprintf(stderr, "No parameters specified.\n");
     }
-  
-  for (int i=1; i < argc; i++)
-    {
-      if (argv[i][0] == '-')
-        {
-          if (strcmp(argv[i], "-listAll") == 0)
-            {
-              listDisplays([screen allDisplays], @"All registered displays");
-            }
-          else if (strcmp(argv[i], "-listActive") == 0)
-            {
-              listDisplays([screen activeDisplays], @"Active displays");
-            }
-          else if (strcmp(argv[i], "-details") == 0 && (i+1 < argc))
-            {
-              displayDetails([screen displayWithName:[NSString stringWithCString:argv[++i]]]);
-            }
-          else if (strcmp(argv[i], "-display") == 0)
-            {
-              display = [screen displayWithName:[NSString stringWithCString:argv[++i]]];
-            }
-          else
-            {
-              fprintf(stderr, "Unknown parameter specified: %s\n", argv[i]);
-            }
-        }
-      else
-        {
-          fprintf(stderr, "No parameters specified.\n");
-        }
-    }
+  }
 
   // if (display)
   //   if (showDetails)
   //     displayDetails(display);
   //   else if (setMode)
   //     setMode()
-      
 
   [screen release];
   [pool release];

--- a/Frameworks/SystemKit/Tests/udisktool/GNUmakefile
+++ b/Frameworks/SystemKit/Tests/udisktool/GNUmakefile
@@ -9,8 +9,8 @@ $(TOOL_NAME)_OBJC_FILES = disktool_main.m
 $(TOOL_NAME)_NEEDS_GUI = no
 
 ADDITIONAL_INCLUDE_DIRS += `pkg-config --cflags udisks2` `pkg-config --cflags dbus-1`
-ADDITIONAL_OBJCFLAGS += -DWITH_UDISKS
-ADDITIONAL_LDFLAGS += -lSystemKit -lgnustep-gui
+ADDITIONAL_OBJCFLAGS +=
+ADDITIONAL_LDFLAGS += -lSystemKit
 
 include $(GNUSTEP_MAKEFILES)/tool.make
 include $(GNUSTEP_MAKEFILES)/ctool.make

--- a/Frameworks/SystemKit/compile_flags.txt
+++ b/Frameworks/SystemKit/compile_flags.txt
@@ -24,7 +24,7 @@
 -Wno-unused-variable
 -Wno-typedef-redefinition
 -g
--fobjc-runtime=gnustep-2.0
+-fobjc-runtime=gnustep-2.2
 -fblocks
 -fconstant-string-class=NSConstantString
 -Iderived_src
@@ -35,13 +35,13 @@
 -DLINUX
 -DWITH_UDISKS
 -F/usr/NextSpace/Frameworks
+-I/usr/lib64/dbus-1.0/include
+-I/usr/lib/x86_64-linux-gnu/dbus-1.0/include
 -I/usr/include/udisks2
 -I/usr/include/glib-2.0
 -I/usr/lib64/glib-2.0/include
+-I/usr/include/gio-unix-2.0
 -I/usr/include/sysprof-4
 -I/usr/include/libmount
 -I/usr/include/blkid
 -I/usr/include/dbus-1.0
--I/usr/lib64/dbus-1.0/include
--I/usr/include/libupower-glib
--I/usr/include/gio-unix-2.0

--- a/Frameworks/SystemKit/compile_flags.txt
+++ b/Frameworks/SystemKit/compile_flags.txt
@@ -33,7 +33,7 @@
 -I/Developer/Headers
 -I/usr/NextSpace/include
 -DLINUX
--DCF_BUS_CONNECTION
+#-DCF_BUS_CONNECTION
 -F/usr/NextSpace/Frameworks
 -I/usr/lib64/dbus-1.0/include
 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include

--- a/Frameworks/SystemKit/compile_flags.txt
+++ b/Frameworks/SystemKit/compile_flags.txt
@@ -34,7 +34,6 @@
 -I/usr/NextSpace/include
 -DLINUX
 -DWITH_UDISKS
--DWITH_UPOWER
 -F/usr/NextSpace/Frameworks
 -I/usr/include/udisks2
 -I/usr/include/glib-2.0

--- a/Frameworks/SystemKit/compile_flags.txt
+++ b/Frameworks/SystemKit/compile_flags.txt
@@ -33,7 +33,6 @@
 -I/Developer/Headers
 -I/usr/NextSpace/include
 -DLINUX
--DWITH_UDISKS
 -F/usr/NextSpace/Frameworks
 -I/usr/lib64/dbus-1.0/include
 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include

--- a/Frameworks/SystemKit/compile_flags.txt
+++ b/Frameworks/SystemKit/compile_flags.txt
@@ -33,6 +33,7 @@
 -I/Developer/Headers
 -I/usr/NextSpace/include
 -DLINUX
+-DCF_BUS_CONNECTION
 -F/usr/NextSpace/Frameworks
 -I/usr/lib64/dbus-1.0/include
 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include


### PR DESCRIPTION
Re-imagine and rewrite of SystemKit integration with D-Bus. Major changes:
- talk to D-Bus directly using `dbus` library without Glib abstractions - new OSEBus* classes family introduced;
- D-Bus signals monitoring now works in NSRunLoop without using timers;
- UDisks and UPower integration rewritten using new OSEBus* classes.