### PR TITLE
Issue #481: various fixes (does not yet fix everything) for a "world"…

### DIFF
--- a/Packaging/RedHat/0.build_libraries.sh
+++ b/Packaging/RedHat/0.build_libraries.sh
@@ -8,50 +8,50 @@ BUILD_RPM=1
 . `dirname $0`/../functions.sh
 . `dirname $0`/../environment.sh
 
-prepare_environment
-if [ $? -eq 1 ];then
+prepare_redhat_environment
+if [ $? -ne 0 ];then
     print_ERR "Failed to setup building environment. Exiting..."
     exit 1
 fi
 
 # Apple Grand Central Dispatch
 `dirname $0`/build_libdispatch.sh $1
-if [ $? -eq 1 ]; then
+if [ $? -ne 0 ]; then
     echo "Aborting..."
     exit 1
 fi
 
 # Apple Core Foundation
 `dirname $0`/build_libcorefoundation.sh $1
-if [ $? -eq 1 ]; then
+if [ $? -ne 0 ]; then
     echo "Aborting..."
     exit 1
 fi
 
 # GNUstep Objective-C runtime
 `dirname $0`/build_libobjc2.sh $1
-if [ $? -eq 1 ]; then
+if [ $? -ne 0 ]; then
     echo "Aborting..."
     exit 1
 fi
 
 # NextSpace Core
 `dirname $0`/build_nextspace-core.sh $1
-if [ $? -eq 1 ]; then
+if [ $? -ne 0 ]; then
     echo "Aborting..."
     exit 1
 fi
 
 # Raster graphics manipulation
 `dirname $0`/build_libwraster.sh $1
-if [ $? -eq 1 ]; then
+if [ $? -ne 0 ]; then
     echo "Aborting..."
     exit 1
 fi
 
 # GNUstep libraries
 `dirname $0`/build_nextspace-gnustep.sh $1
-if [ $? -eq 1 ]; then
+if [ $? -ne 0 ]; then
     echo "Aborting..."
     exit 1
 fi

--- a/Packaging/RedHat/1.build_frameworks.sh
+++ b/Packaging/RedHat/1.build_frameworks.sh
@@ -7,7 +7,11 @@ BUILD_RPM=1
 . `dirname $0`/../functions.sh
 . `dirname $0`/../environment.sh
 
-prepare_environment
+prepare_redhat_environment
+if [ $? -ne 0 ];then
+    print_ERR "Failed to setup building environment. Exiting..."
+    exit 1
+fi
 
 LOG_FILE=${CWD}/frameworks_build.log
 SPEC_FILE=${PROJECT_DIR}/Frameworks/nextspace-frameworks.spec

--- a/Packaging/RedHat/2.build_applications.sh
+++ b/Packaging/RedHat/2.build_applications.sh
@@ -7,7 +7,11 @@ BUILD_RPM=1
 . `dirname $0`/../functions.sh
 . `dirname $0`/../environment.sh
 
-prepare_environment
+prepare_redhat_environment
+if [ $? -ne 0 ];then
+    print_ERR "Failed to setup building environment. Exiting..."
+    exit 1
+fi
 
 LOG_FILE=/dev/null
 SPEC_FILE=${PROJECT_DIR}/Applications/nextspace-applications.spec

--- a/Packaging/RedHat/3.build_selinux.sh
+++ b/Packaging/RedHat/3.build_selinux.sh
@@ -13,8 +13,8 @@ if [ $# -eq 0 ];then
     exit 1
 fi
 
-prepare_environment
-if [ $? -eq 1 ];then
+prepare_redhat_environment
+if [ $? -ne 0 ];then
     print_ERR "Failed to setup building environment. Exiting..."
     exit 1
 fi
@@ -23,7 +23,7 @@ REPO_DIR=$1
 
 # NextSpace SELinux
 `dirname $0`/build_nextspace-selinux.sh $1
-if [ $? -eq 1 ]; then
+if [ $? -ne 0 ]; then
     echo "Aborting..."
     exit 1
 fi

--- a/Packaging/RedHat/build_all.sh
+++ b/Packaging/RedHat/build_all.sh
@@ -13,8 +13,8 @@ if [ $# -eq 0 ];then
     exit 1
 fi
 
-prepare_environment
-if [ $? -eq 1 ];then
+prepare_redhat_environment
+if [ $? -ne 0 ];then
     print_ERR "Failed to setup building environment. Exiting..."
     exit 1
 fi
@@ -26,17 +26,17 @@ rm -rf $1/Packaging/RedHat/$OS_ID-$OS_VERSION/NSDeveloper/*
 rm -rf $1/Packaging/RedHat/$OS_ID-$OS_VERSION/NSUser/*
 
 `dirname $0`/0.build_libraries.sh $1
-if [ $? -eq 1 ]; then
+if [ $? -ne 0 ]; then
     echo "Aborting..."
     exit 1
 fi
 `dirname $0`/1.build_frameworks.sh $1
-if [ $? -eq 1 ]; then
+if [ $? -ne 0 ]; then
     echo "Aborting..."
     exit 1
 fi
 `dirname $0`/2.build_applications.sh $1
-if [ $? -eq 1 ]; then
+if [ $? -ne 0 ]; then
     echo "Aborting..."
     exit 1
 fi

--- a/Packaging/RedHat/nextspace_install.sh
+++ b/Packaging/RedHat/nextspace_install.sh
@@ -36,7 +36,7 @@ fi
 if [ "$EPEL_REPO" != "" ]; then
     echo -n "Checking for EPEL repository installed..."
     yum repolist | grep "epel" 2>&1 > /dev/null
-    if [ $? -eq 1 ];then
+    if [ $? -ne 0 ];then
         echo "Adding EPEL repository..."
         yum -y install $EPEL_REPO 2>&1 > /dev/null
     else

--- a/Packaging/environment.sh
+++ b/Packaging/environment.sh
@@ -154,8 +154,8 @@ else
 fi
 # Compiler
 if [ "$OS_ID" = "fedora" ] || [ "$OS_LIKE" = "rhel" ] || [ "$OS_ID" = "debian" ] || [ "$OS_ID" = "ubuntu" ] || [ "$OS_ID" = "ultramarine" ]; then
-  which clang 2>&1 > /dev/null || `echo "No clang compiler found. Please install clang package."; exit 1`
+  which clang 2>&1 > /dev/null || { echo "No clang compiler found. Please install clang package."; exit 1; }
   C_COMPILER=`which clang`
-  which clang++ 2>&1 > /dev/null || `echo "No clang++ compiler found. Please install clang++ package."; exit 1`
+  which clang++ 2>&1 > /dev/null || { echo "No clang++ compiler found. Please install clang++ package."; exit 1; }
   CXX_COMPILER=`which clang++`
 fi

--- a/Packaging/functions.sh
+++ b/Packaging/functions.sh
@@ -52,7 +52,7 @@ install_rpm()
     else
         INST_CMD=reinstall
     fi
-    sudo yum -y $INST_CMD $2
+    sudo yum -y $INST_CMD $2 || exit 1
 }
 
 # Bold


### PR DESCRIPTION
Things should work now.

This is what I do to successfully build the RPMs:

Script 1: `build-world.sh`:
```
#!/bin/sh

errorExit() {
	echo "*** $*" 1>&2
	exit 1
}

( cd /export ) || errorExit "Error chdir '/export', have you mapped it?"

OWNERUID="`ls -nd /export | awk '{ print $3 }'`"
GROUPUID="`ls -nd /export | awk '{ print $4 }'`"
FEDORA="`cat /etc/fedora-release | awk '{ print $3 }'`"

CMD="dnf install -y sudo git openssh-clients which binutils binutils-gold curl clang which git"
echo "$CMD"
$CMD || errorExit "Error installing required packages."

cd ~ || errorExit "Error cd ~"
if ! ( cd nextspace ); then
	CMD="git clone https://github.com/trunkmaster/nextspace.git"
	echo "$CMD"
	$CMD || errorExit "Error cloning nextspace repo."
fi

NEXTSPACE_DIR="$(cd nextspace; pwd)"

CMD="cd nextspace/Packaging/RedHat"
echo $CMD
$CMD || errorExit "Error '$CMD'."

# Fake CI build (suppress need for systemctl)
GITHUB_ACTIONS=true
export GITHUB_ACTIONS

export PATH=/usr/local/bin:/usr/bin:/bin

for script in \
	0.build_libraries.sh \
	1.build_frameworks.sh \
	2.build_applications.sh; do
	CMD="./${script}"
	echo $CMD
	$CMD || errorExit "Error '$CMD'."
done

cd ..
echo "Copying RPM files..."
cp -v $(find . -name '*.rpm') /export/ || errorExit "Error copying RPMs"
echo "Fixing RPM files ownership..."
chown ${OWNERUID}:${GROUPUID} /export/*.rpm || errorExit "Error changing ownership in RPMs."
echo "Fixing build directory ownership..."
chown -R ${OWNERUID}:${GROUPUID} "${NEXTSPACE_DIR}"
echo "Done."
```

Script 2 `build-nextspace-in-docker.sh`:
```
#!/bin/sh
mkdir -p /tmp/nextspace-build && docker run -ti -w `pwd` -v /tmp/nextspace-build:/export -v `pwd`:`pwd` amd64/fedora:42 sh build-world.sh
```

Would that be worth documenting somewhere for others to bake their own builds?