### PR TITLE
fix(Workspace): wrong assumption caused WM to SEGV when a focused window was being unmanaged by the WM and there's not any other window to focus

### DIFF
--- a/Applications/Workspace/WM/window.c
+++ b/Applications/Workspace/WM/window.c
@@ -1556,7 +1556,8 @@ void wUnmanageWindow(WWindow *wwin, Bool restore, Bool destroyed)
 
   oapp = wApplicationOf(wwin->main_window);
 
-  if (wasFocused) {
+  // `wasFocused` doesn't guarantee that `new_focused_window` isn't NULL.
+  if (wasFocused && new_focused_window != NULL) {
     WApplication *napp = wApplicationOf(new_focused_window->main_window);
 
     if (owner && new_focused_window != owner) {


### PR DESCRIPTION
If `wasFocused` is `true`, the value of `new_focused_window` shouldn't be NULL, but in a specific scenario, it is, and the window manager just SEGV. I triggered this SIGSEGV myself while using NEXTSPACE. Debian 12 under Bedrock Linux (no influence of other distros, only Debian packages & build tools).

The flow of:
```
1534 | if (!wwin->prev && !wwin->next) {
1535 |   /* was the only window */
1536 |   scr->focused_window = NULL;
1537 |   new_focused_window = NULL;
```

doesn't set `wasFocused` to `false`, but `new_focused_window` is NULL, and this code flow segfaults the entire WM.

Crash:
```
Thread 4 "Workspace" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffeefd56c0 (LWP 70817)]
0x000055555561d3f3 in wUnmanageWindow (wwin=0x7fffe0036fb0, restore=0,
    destroyed=1) at WM/window.c:1560
1560	    WApplication *napp = wApplicationOf(new_focused_window->main_window);
```