### PR TITLE
RedHat build scripts: support for overriding release

### DIFF
--- a/Packaging/RedHat/0.build_libraries.sh
+++ b/Packaging/RedHat/0.build_libraries.sh
@@ -8,53 +8,25 @@ BUILD_RPM=1
 . `dirname $0`/../functions.sh
 . `dirname $0`/../environment.sh
 
-prepare_redhat_environment
-if [ $? -ne 0 ];then
-    print_ERR "Failed to setup building environment. Exiting..."
-    exit 1
-fi
+prepare_redhat_environment || error_exit "Failed to setup building environment. Exiting..."
 
 # Apple Grand Central Dispatch
-`dirname $0`/build_libdispatch.sh $1
-if [ $? -ne 0 ]; then
-    echo "Aborting..."
-    exit 1
-fi
+`dirname $0`/build_libdispatch.sh "$@" || abort_with_message
 
 # Apple Core Foundation
-`dirname $0`/build_libcorefoundation.sh $1
-if [ $? -ne 0 ]; then
-    echo "Aborting..."
-    exit 1
-fi
+`dirname $0`/build_libcorefoundation.sh "$@" || abort_with_message
 
 # GNUstep Objective-C runtime
-`dirname $0`/build_libobjc2.sh $1
-if [ $? -ne 0 ]; then
-    echo "Aborting..."
-    exit 1
-fi
+`dirname $0`/build_libobjc2.sh "$@" || abort_with_message
 
 # NextSpace Core
-`dirname $0`/build_nextspace-core.sh $1
-if [ $? -ne 0 ]; then
-    echo "Aborting..."
-    exit 1
-fi
+`dirname $0`/build_nextspace-core.sh "$@" || abort_with_message
 
 # Raster graphics manipulation
-`dirname $0`/build_libwraster.sh $1
-if [ $? -ne 0 ]; then
-    echo "Aborting..."
-    exit 1
-fi
+`dirname $0`/build_libwraster.sh "$@" || abort_with_message
 
 # GNUstep libraries
-`dirname $0`/build_nextspace-gnustep.sh $1
-if [ $? -ne 0 ]; then
-    echo "Aborting..."
-    exit 1
-fi
+`dirname $0`/build_nextspace-gnustep.sh "$@" || abort_with_message
 
 print_OK " Build and install of NEXTSPACE Libraries SUCCEEDED!"
 

--- a/Packaging/RedHat/1.build_frameworks.sh
+++ b/Packaging/RedHat/1.build_frameworks.sh
@@ -7,11 +7,7 @@ BUILD_RPM=1
 . `dirname $0`/../functions.sh
 . `dirname $0`/../environment.sh
 
-prepare_redhat_environment
-if [ $? -ne 0 ];then
-    print_ERR "Failed to setup building environment. Exiting..."
-    exit 1
-fi
+prepare_redhat_environment || error_exit "Failed to setup building environment. Exiting..."
 
 LOG_FILE=${CWD}/frameworks_build.log
 SPEC_FILE=${PROJECT_DIR}/Packaging/RedHat/SPECS/nextspace-frameworks.spec
@@ -32,12 +28,12 @@ mv ${PROJECT_DIR}/nextspace-frameworks-${FRAMEWORKS_VERSION}.tar.gz ${RPM_SOURCE
 spectool -g -R ${SPEC_FILE}
 
 print_H2 "===== Building nextspace-frameworks package..."
-rpmbuild -bb ${SPEC_FILE}
+run_rpmbuild ${SPEC_FILE} "$@"
 STATUS=$?
 if [ $STATUS -eq 0 ]; then 
     print_OK " Building of NEXTSPACE Frameworks RPM SUCCEEDED!"
     print_H2 "===== Installing nextspace-frameworks RPMs..."
-    FRAMEWORKS_VERSION=`rpm_version ${SPEC_FILE}`
+    FRAMEWORKS_VERSION=`rpm_version ${SPEC_FILE} "$@"`
     
     install_rpm nextspace-frameworks ${RPMS_DIR}/nextspace-frameworks-${FRAMEWORKS_VERSION}.rpm
     mv ${RPMS_DIR}/nextspace-frameworks-${FRAMEWORKS_VERSION}.rpm ${RELEASE_USR}

--- a/Packaging/RedHat/2.build_applications.sh
+++ b/Packaging/RedHat/2.build_applications.sh
@@ -7,11 +7,7 @@ BUILD_RPM=1
 . `dirname $0`/../functions.sh
 . `dirname $0`/../environment.sh
 
-prepare_redhat_environment
-if [ $? -ne 0 ];then
-    print_ERR "Failed to setup building environment. Exiting..."
-    exit 1
-fi
+prepare_redhat_environment || error_exit "Failed to setup building environment. Exiting..."
 
 LOG_FILE=/dev/null
 SPEC_FILE=${PROJECT_DIR}/Packaging/RedHat/SPECS/nextspace-applications.spec
@@ -36,12 +32,12 @@ mv ${PROJECT_DIR}/nextspace-applications-${APPLICATIONS_VERSION}.tar.gz ${RPM_SO
 spectool -g -R ${SPEC_FILE}
 
 print_H2 "===== Building nextspace-applications package..."
-rpmbuild -bb ${SPEC_FILE}
+run_rpmbuild ${SPEC_FILE} "$@"
 STATUS=$?
 if [ $STATUS -eq 0 ]; then 
     print_OK " Building of NEXTSPACE Applications RPM SUCCEEDED!"
     print_H2 "===== Installing nextspace-applications RPMs..."
-    APPLICATIONS_VERSION=`rpm_version ${SPEC_FILE}`
+    APPLICATIONS_VERSION=`rpm_version ${SPEC_FILE} "$@"`
 
     install_rpm nextspace-applications ${RPMS_DIR}/nextspace-applications-${APPLICATIONS_VERSION}.rpm
     mv ${RPMS_DIR}/nextspace-applications-${APPLICATIONS_VERSION}.rpm ${RELEASE_USR}

--- a/Packaging/RedHat/3.build_selinux.sh
+++ b/Packaging/RedHat/3.build_selinux.sh
@@ -8,25 +8,10 @@ BUILD_RPM=1
 . `dirname $0`/../functions.sh
 . `dirname $0`/../environment.sh
 
-if [ $# -eq 0 ];then
-    print_help
-    exit 1
-fi
-
-prepare_redhat_environment
-if [ $? -ne 0 ];then
-    print_ERR "Failed to setup building environment. Exiting..."
-    exit 1
-fi
-
-REPO_DIR=$1
+prepare_redhat_environment || error_exit "Failed to setup building environment. Exiting..."
 
 # NextSpace SELinux
-`dirname $0`/build_nextspace-selinux.sh $1
-if [ $? -ne 0 ]; then
-    echo "Aborting..."
-    exit 1
-fi
+`dirname $0`/build_nextspace-selinux.sh "$@" || abort_with_message
 
 print_OK " Build and install of NEXTSPACE SELinux SUCCEEDED!"
 

--- a/Packaging/RedHat/SPECS/libcorefoundation.spec
+++ b/Packaging/RedHat/SPECS/libcorefoundation.spec
@@ -1,10 +1,11 @@
 %global toolchain clang
+%{!?release:%global release 1}
 %define CFNET_VERSION 129.20
 
 Name:       libcorefoundation
 Version:    5.9.2
 Epoch:      0
-Release:    1%{?dist}
+Release:    %{release}%{?dist}
 Summary:    Apple CoreFoundation framework.
 License:    Apache 2.0
 URL:        https://github.com/trunkmaster/apple-corefoundation

--- a/Packaging/RedHat/SPECS/libdispatch.spec
+++ b/Packaging/RedHat/SPECS/libdispatch.spec
@@ -1,9 +1,10 @@
 %global toolchain clang
+%{!?release:%global release 1}
 
 Name:		libdispatch
 Epoch:		1
 Version:	5.9.2
-Release:	1%{?dist}
+Release:	%{release}%{?dist}
 Summary:	Grand Central Dispatch (GCD or libdispatch).
 License:	Apache 2.0
 URL:		https://github.com/apple/swift-corelibs-libdispatch

--- a/Packaging/RedHat/SPECS/libobjc2.spec
+++ b/Packaging/RedHat/SPECS/libobjc2.spec
@@ -1,9 +1,10 @@
 %global toolchain clang
+%{!?release:%global release 0}
 %global _hardened_build 0
 
 Name:	libobjc2
 Version:  2.2.1
-Release:  0%{?dist}
+Release:  %{release}%{?dist}
 Summary:  GNUstep Objecttive-C runtime library.
 License:  GPL v2.0
 URL:      https://github.com/gnustep/libobjc2

--- a/Packaging/RedHat/SPECS/libwraster.spec
+++ b/Packaging/RedHat/SPECS/libwraster.spec
@@ -1,9 +1,10 @@
 %global toolchain clang
+%{!?release:%global release 0}
 %define WRASTER_VERSION 7.0.1
 
 Name:           libwraster
 Version:        %{WRASTER_VERSION}
-Release:        0%{?dist}
+Release:        %{release}%{?dist}
 Summary:        Raster graphics library.
 Group:          Libraries/NextSpace
 License:        GPLv3

--- a/Packaging/RedHat/SPECS/nextspace-applications.spec
+++ b/Packaging/RedHat/SPECS/nextspace-applications.spec
@@ -1,8 +1,9 @@
 %global toolchain clang
+%{!?release:%global release 0}
 
 Name:           nextspace-applications
 Version:        0.95
-Release:        0%{?dist}
+Release:        %{release}%{?dist}
 Summary:        NextSpace desktop core applications.
 
 Group:          Libraries/NextSpace

--- a/Packaging/RedHat/SPECS/nextspace-core.spec
+++ b/Packaging/RedHat/SPECS/nextspace-core.spec
@@ -1,11 +1,12 @@
 %global debug_package %{nil}
+%{!?release:%global release 12}
 %global _hardened_build 0
 
 %define MAKE_VERSION    2_9_2
 
 Name:		nextspace-core
 Version:	0.95
-Release:	12%{?dist}
+Release:	%{release}%{?dist}
 Summary:	NextSpace filesystem hierarchy and system files.
 License:	GPLv2
 URL:		  http://github.com/trunkmaster/nextspace

--- a/Packaging/RedHat/SPECS/nextspace-frameworks.spec
+++ b/Packaging/RedHat/SPECS/nextspace-frameworks.spec
@@ -1,8 +1,9 @@
 %global toolchain clang
+%{!?release:%global release 0}
 
 Name:           nextspace-frameworks
 Version:        0.95
-Release:        0%{?dist}
+Release:        %{release}%{?dist}
 Summary:        NextSpace core libraries.
 Group:          Libraries/NextSpace
 License:        GPLv2

--- a/Packaging/RedHat/SPECS/nextspace-gnustep.spec
+++ b/Packaging/RedHat/SPECS/nextspace-gnustep.spec
@@ -1,4 +1,5 @@
 %global toolchain clang
+%{!?release:%global release 1}
 %global _hardened_build 0
 
 %define GS_REPO       https://github.com/gnustep
@@ -12,7 +13,7 @@
 
 Name:       nextspace-gnustep
 Version:    %{BASE_VERSION}_%{GUI_VERSION}
-Release:    1%{?dist}
+Release:    %{release}%{?dist}
 Summary:    GNUstep libraries.
 
 Group:      Libraries/NextSpace

--- a/Packaging/RedHat/SPECS/nextspace-selinux.spec
+++ b/Packaging/RedHat/SPECS/nextspace-selinux.spec
@@ -1,9 +1,10 @@
 %global selinux_variants mls targeted
 %global selinux_modules ns-core ns-gdomap ns-gpbs ns-gdnc ns-Login
+%{!?release:%global release 0}
 
 Name:		nextspace-selinux
 Version:	0.91
-Release:	0%{?dist}
+Release:	%{release}%{?dist}
 Summary:	SELinux policies for NEXTSPACE components.
 
 Group:		Libraries/NextSpace

--- a/Packaging/RedHat/build_all.sh
+++ b/Packaging/RedHat/build_all.sh
@@ -8,36 +8,18 @@ BUILD_RPM=1
 . `dirname $0`/../functions.sh
 . `dirname $0`/../environment.sh
 
-if [ $# -eq 0 ];then
-    print_help
-    exit 1
-fi
+NEXTSPACE_DIR="$(cd "$(dirname "$0")/../.."; pwd)"
 
-prepare_redhat_environment
-if [ $? -ne 0 ];then
-    print_ERR "Failed to setup building environment. Exiting..."
-    exit 1
-fi
+test -d "${NEXTSPACE_DIR}" || errorExit "Invalid NEXTSPACE directory: '${NEXTSPACE_DIR}'."
+prepare_redhat_environment || error_exit "Failed to setup building environment. Exiting..."
 
 rm -rf ~/rpmbuild/SOURCES/*
 rm -rf ~/rpmbuild/BUILD/*
 rm -rf ~/rpmbuild/BUILDROOT/*
-rm -rf $1/Packaging/RedHat/$OS_ID-$OS_VERSION/NSDeveloper/*
-rm -rf $1/Packaging/RedHat/$OS_ID-$OS_VERSION/NSUser/*
+rm -rf "${NEXTSPACE_DIR}/Packaging/RedHat/$OS_ID-$OS_VERSION/NSDeveloper"/*
+rm -rf "${NEXTSPACE_DIR}/Packaging/RedHat/$OS_ID-$OS_VERSION/NSUser"/*
 
-`dirname $0`/0.build_libraries.sh $1
-if [ $? -ne 0 ]; then
-    echo "Aborting..."
-    exit 1
-fi
-`dirname $0`/1.build_frameworks.sh $1
-if [ $? -ne 0 ]; then
-    echo "Aborting..."
-    exit 1
-fi
-`dirname $0`/2.build_applications.sh $1
-if [ $? -ne 0 ]; then
-    echo "Aborting..."
-    exit 1
-fi
+`dirname $0`/0.build_libraries.sh "$@" || abort_with_message
+`dirname $0`/1.build_frameworks.sh "$@" || abort_with_message
+`dirname $0`/2.build_applications.sh "$@" || abort_with_message
 

--- a/Packaging/RedHat/build_libcorefoundation.sh
+++ b/Packaging/RedHat/build_libcorefoundation.sh
@@ -6,7 +6,7 @@ BUILD_RPM=1
 . `dirname $0`/../environment.sh
 
 SPEC_FILE=${PROJECT_DIR}/Packaging/RedHat/SPECS/libcorefoundation.spec
-CF_VERSION=`rpm_version ${SPEC_FILE}`
+CF_VERSION=`rpm_version ${SPEC_FILE} "$@"`
 
 print_H1 " Building Core Foundation (libcorefoundation) package..."
 print_H2 "===== Install Core Foundation build dependencies..."
@@ -20,7 +20,7 @@ curl -L https://github.com/trunkmaster/apple-corefoundation/archive/refs/tags/${
 spectool -g -R ${SPEC_FILE}
 
 print_H2 "===== Building CoreFoundation package..."
-rpmbuild -bb ${SPEC_FILE}
+run_rpmbuild ${SPEC_FILE} "$@"
 STATUS=$?
 if [ $STATUS -eq 0 ]; then 
     print_OK " Building of Core Foundation library RPM SUCCEEDED!"

--- a/Packaging/RedHat/build_libdispatch.sh
+++ b/Packaging/RedHat/build_libdispatch.sh
@@ -12,7 +12,7 @@ if [ "${OS_ID}" = "fedora" ]; then
 fi
 
 SPEC_FILE=${PROJECT_DIR}/Packaging/RedHat/SPECS/libdispatch.spec
-DISPATCH_VERSION=`rpm_version ${SPEC_FILE}`
+DISPATCH_VERSION=`rpm_version ${SPEC_FILE} "$@"`
 
 # libdispatch
 print_H1 " Building Grand Central Dispatch (libdispatch) package..."
@@ -26,7 +26,7 @@ curl -L https://github.com/apple/swift-corelibs-libdispatch/archive/swift-${VER}
 spectool -g -R ${SPEC_FILE}
 
 print_H2 "===== Building libdispatch package..."
-rpmbuild -bb ${SPEC_FILE}
+run_rpmbuild ${SPEC_FILE} "$@"
 STATUS=$?
 if [ $STATUS -eq 0 ]; then 
     print_OK " Building of Grand Central Dispatch library RPM SUCCEEDED!"

--- a/Packaging/RedHat/build_libobjc2.sh
+++ b/Packaging/RedHat/build_libobjc2.sh
@@ -6,7 +6,7 @@ BUILD_RPM=1
 . `dirname $0`/../environment.sh
 
 SPEC_FILE=${PROJECT_DIR}/Packaging/RedHat/SPECS/libobjc2.spec
-OBJC2_VERSION=`rpm_version ${SPEC_FILE}`
+OBJC2_VERSION=`rpm_version ${SPEC_FILE} "$@"`
 
 print_H1 " Building Objective-C Runtime(libobjc2) package..."
 print_H2 "===== Install libobjc2 build dependencies..."
@@ -17,7 +17,7 @@ print_H2 "===== Downloading libobjc2 sources..."
 spectool -g -R ${SPEC_FILE}
 
 print_H2 "===== Building libobjc2 package..."
-rpmbuild -bb ${SPEC_FILE}
+run_rpmbuild ${SPEC_FILE} "$@"
 STATUS=$?
 if [ $STATUS -eq 0 ]; then 
     print_OK " Building of Objective-C Runtime RPM SUCCEEDED!"

--- a/Packaging/RedHat/build_libwraster.sh
+++ b/Packaging/RedHat/build_libwraster.sh
@@ -24,10 +24,10 @@ mv ${PROJECT_DIR}/Libraries/libwraster-${WRASTER_VERSION}.tar.gz ${RPM_SOURCES_D
 
 spectool -g -R ${SPEC_FILE}
 print_H2 "===== Building libwraster RPM..."
-rpmbuild -bb ${SPEC_FILE}
+run_rpmbuild ${SPEC_FILE} "$@"
 STATUS=$?
 if [ $STATUS -eq 0 ]; then 
-    WRASTER_VERSION=`rpm_version ${SPEC_FILE}`
+    WRASTER_VERSION=`rpm_version ${SPEC_FILE} "$@"`
     print_OK " Building libwraster RPM SUCCEEDED!"
 
     install_rpm libwraster ${RPMS_DIR}/libwraster-${WRASTER_VERSION}.rpm

--- a/Packaging/RedHat/build_nextspace-core.sh
+++ b/Packaging/RedHat/build_nextspace-core.sh
@@ -22,12 +22,12 @@ rm ./nextspace-os_files-${CORE_VERSION}/GNUmakefile
 tar zcf ${RPM_SOURCES_DIR}/nextspace-os_files-${CORE_VERSION}.tar.gz nextspace-os_files-${CORE_VERSION}
 cd $CWD
 
-CORE_VERSION=`rpm_version ${SPEC_FILE}`
+CORE_VERSION=`rpm_version ${SPEC_FILE} "$@"`
 cp ${PROJECT_DIR}/Libraries/gnustep/nextspace.fsl ${RPM_SOURCES_DIR}
 spectool -g -R ${SPEC_FILE}
 
 print_H2 "===== Building NEXTSPACE core components (nextspace-core) RPM..."
-rpmbuild -bb ${SPEC_FILE}
+run_rpmbuild ${SPEC_FILE} "$@"
 STATUS=$?
 if [ $STATUS -eq 0 ]; then 
     print_OK " Building of NEXTSPACE Core RPM SUCCEEDED!"

--- a/Packaging/RedHat/build_nextspace-gnustep.sh
+++ b/Packaging/RedHat/build_nextspace-gnustep.sh
@@ -8,7 +8,7 @@ BUILD_RPM=1
 . /etc/profile.d/nextspace.sh
 
 SPEC_FILE=${PROJECT_DIR}/Packaging/RedHat/SPECS/nextspace-gnustep.spec
-GNUSTEP_VERSION=`rpm_version ${SPEC_FILE}`
+GNUSTEP_VERSION=`rpm_version ${SPEC_FILE} "$@"`
 
 print_H1 " Building NEXTSPACE GNUstep (nextspace-gnustep) package..."
 cp ${PROJECT_DIR}/Libraries/gnustep/gdnc-local.service ${RPM_SOURCES_DIR}
@@ -39,7 +39,7 @@ print_H2 "===== Downloading GNUstep sources..."
 spectool -g -R ${SPEC_FILE}
 
 print_H2 "===== Building GNUstep package..."
-rpmbuild -bb ${SPEC_FILE}
+run_rpmbuild ${SPEC_FILE} "$@"
 STATUS=$?
 if [ $STATUS -eq 0 ]; then 
     print_OK " Building of NEXTSPACE GNUstep RPM SUCCEEDED!"

--- a/Packaging/RedHat/build_nextspace-selinux.sh
+++ b/Packaging/RedHat/build_nextspace-selinux.sh
@@ -33,11 +33,11 @@ cp ${PROJECT_DIR}/Libraries/selinux/ns-gpbs.fc ${RPM_SOURCES_DIR}
 cp ${PROJECT_DIR}/Libraries/selinux/ns-gpbs.if ${RPM_SOURCES_DIR}
 cp ${PROJECT_DIR}/Libraries/selinux/ns-gpbs.te ${RPM_SOURCES_DIR}
 
-SELINUX_VERSION=`rpm_version ${SPEC_FILE}`
+SELINUX_VERSION=`rpm_version ${SPEC_FILE} "$@"`
 spectool -g -R ${SPEC_FILE}
 
 print_H2 "===== Building NEXTSPACE SELinux components (nextspace-selinux) RPM..."
-rpmbuild -bb ${SPEC_FILE}
+run_rpmbuild ${SPEC_FILE} "$@"
 STATUS=$?
 if [ $STATUS -eq 0 ]; then 
     print_OK " Building of NEXTSPACE SELinux RPM SUCCEEDED!"

--- a/Packaging/functions.sh
+++ b/Packaging/functions.sh
@@ -30,7 +30,21 @@ uninstall_packages() {
 
 rpm_version()
 {
-    echo `rpmspec -q --qf "%{version}-%{release}.%{arch}:" $1 | awk -F: '{print $1}'`
+    SPEC_FILE=$1
+    shift
+    RELEASE=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --release) shift; RELEASE="$1"; test -n "$RELEASE" || error_exit "Missing argument to '--release'.";;
+            *) error_exit "Unsupported argument: '$1'.";;
+        esac
+        shift
+    done
+    if [ -n "$RELEASE" ]; then
+        rpmspec --define "release $RELEASE" -q --qf "%{version}-%{release}.%{arch}:" ${SPEC_FILE} | awk -F: '{print $1}'
+    else
+        rpmspec -q --qf "%{version}-%{release}.%{arch}:" ${SPEC_FILE} | awk -F: '{print $1}'
+    fi
 }
 
 # $1 - path to spec file
@@ -40,7 +54,29 @@ build_rpm()
     spectool -g -R ${SPEC_FILE}
     DEPS=`rpmspec -q --buildrequires ${SPEC_FILE} | awk -c '{print $1}'`
     sudo yum -y install ${DEPS}
-    rpmbuild -bb ${SPEC_FILE}
+    run_rpmbuild ${SPEC_FILE}
+}
+
+# $1 - path to spec file, optional: $2, $3, ... - rpm build flags
+run_rpmbuild()
+{
+    SPEC_FILE=$1
+    shift
+    RELEASE=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --release) shift; RELEASE="$1"; test -n "$RELEASE" || error_exit "Missing argument to '--release'.";;
+            *) error_exit "Unsupported argument: '$1'.";;
+        esac
+        shift
+    done
+    if [ -n "$RELEASE" ]; then
+        echo "rpmbuild --define \"release $RELEASE\" -bb ${SPEC_FILE}"
+        rpmbuild --define "release $RELEASE" -bb ${SPEC_FILE}
+    else
+        echo "rpmbuild -bb ${SPEC_FILE}"
+        rpmbuild -bb ${SPEC_FILE}
+    fi
 }
 
 # $1 - package name, $2 - rpm file path
@@ -99,20 +135,6 @@ print_ERR()
     echo -e -n "\e[0m"
 }
 
-print_help()
-{
-    SCRIPT_NAME=`basename $0`
-    print_ERR " ERROR: No NEXTSPACE directory specified."
-    printf "\n"
-    print_H2 "You have to specify directory where NEXTSPACE git clone resides."
-    print_H2 "For example, consider this scenario:"
-    printf "\n"
-    print_H2 "$ git clone https://github.com/trunkmaster/nextspace"
-    print_H2 "$ cd nextspace"
-    print_H2 "$ ./scripts/$SCRIPT_NAME ~/nextspace"
-    printf "\n"
-}
-
 prepare_redhat_environment() 
 {
     print_H1 " Prepare build environment"
@@ -145,4 +167,14 @@ prepare_redhat_environment()
     if [ "${BUILD_TOOLS}" != "" ]; then
         sudo dnf -y install ${BUILD_TOOLS}
     fi
+}
+
+error_exit() {
+    print_ERR "*** $*"
+    exit 1
+}
+
+abort_with_message() {
+    echo "Aborting..."
+    exit 1
 }


### PR DESCRIPTION
This PR aims to provide better supports for frequent (nightly?) RPM builds from the master branch. The main obstacle is versioning: if a build comes out with the same version as the previous one, the RPMs are not cleanly upgradable. This is solved by making the `Release` field in the RPM version overridable and setting it from the command line. Along with this I have removed some boilerplate code and simplified the build automation (I hope you agree). 

1. All RedHat build scripts apart from`build_all.sh` can be called as before, i.e. with no arguments.
2. Optionally, they can be called with a command line argument `--release <release>` which will cause `<release>` to override the respective values from the `.spec` files when building the RPMs.
3. The `build_all.sh` script will now determine `${NEXTSPACE_DIR}` automatically, i.e. no longer needs it as a command line argument. Also, optionally, it can be called the same way as the other build scripts and will pass on the release override.

Practical example:
```
DATE=$(date +%Y%m%d)
CMD="./build_all.sh --release ${DATE}"
echo "$CMD"
$CMD
```

The syntax for overriding stuff in the `.spec` files used by `rpmspec` and `rpmbuild` is awkward: `--define "foo bar"`. I have opted not to use `eval` or bashisms which is why the two functions `rpm_version()` and `run_rpmbuild()` in `Packaging/functions.sh` got a bit lengthy.

Optionally this here could be used for setting up nightly builds from which people could pull the RPMs and update their installations. As a nice-to-have this also could help identifying regressions in the RPM builds early. 