### PR TITLE
RPM builds: fix broken RPM updates for some packages

### DIFF
--- a/Packaging/RedHat/SPECS/libcorefoundation.spec
+++ b/Packaging/RedHat/SPECS/libcorefoundation.spec
@@ -140,8 +140,11 @@ ln -s ../Frameworks/CFNetwork.framework/Versions/${CFNET_VERSION}/libCFNetwork.s
 /usr/NextSpace/Frameworks/CFNetwork.framework/Headers
 
 %postun
-/bin/rm -rf /usr/NextSpace/Frameworks/CoreFoundation.framework
-/bin/rm -rf /usr/NextSpace/Frameworks/CFNetwork.framework
+if [ $1 -eq 0 ]; then
+    # full uninstall:
+    /bin/rm -rf /usr/NextSpace/Frameworks/CoreFoundation.framework
+    /bin/rm -rf /usr/NextSpace/Frameworks/CFNetwork.framework
+fi
 
 %changelog
 * Tue Nov 5 2024 Andres Morales <armm77@icloud.com>

--- a/Packaging/RedHat/SPECS/libobjc2.spec
+++ b/Packaging/RedHat/SPECS/libobjc2.spec
@@ -108,7 +108,7 @@ if [ -f /usr/NextSpace/include/Block.h ];then
 fi
 
 %postun devel
-if [ -f /usr/NextSpace/include/Block-libdispatch.h ];then
+if [ $1 -eq 0 -a -f /usr/NextSpace/include/Block-libdispatch.h ];then
 	mv /usr/NextSpace/include/Block-libdispatch.h /usr/NextSpace/include/Block.h
 	rm /usr/NextSpace/include/Block.h
 fi

--- a/Packaging/RedHat/SPECS/nextspace-applications.spec
+++ b/Packaging/RedHat/SPECS/nextspace-applications.spec
@@ -137,7 +137,7 @@ if [ $1 -eq 0 ]; then
 fi
 
 %postun
-if [ -f /usr/NextSpace/Preferences/Login ]; then
+if [ $1 -eq 0 -a -f /usr/NextSpace/Preferences/Login ]; then
     rm /usr/NextSpace/Preferences/Login
 fi
 

--- a/Packaging/RedHat/SPECS/nextspace-frameworks.spec
+++ b/Packaging/RedHat/SPECS/nextspace-frameworks.spec
@@ -129,8 +129,11 @@ fi
 #%preun
 
 %postun
-/bin/rm -rf /usr/NextSpace/Frameworks/DesktopKit.framework
-/bin/rm /etc/fonts/conf.d/25-nextspace-fonts.conf
+if [ $1 -eq 0 ]; then
+    # full uninstall:
+    /bin/rm -rf /usr/NextSpace/Frameworks/DesktopKit.framework
+    /bin/rm /etc/fonts/conf.d/25-nextspace-fonts.conf
+fi
 /sbin/ldconfig
 
 %changelog

--- a/Packaging/RedHat/SPECS/nextspace-gnustep.spec
+++ b/Packaging/RedHat/SPECS/nextspace-gnustep.spec
@@ -317,7 +317,7 @@ elif  [ $1 -eq 1 ]; then
 fi
 
 %postun
-if [ -d /usr/NextSpace/Preferences ]; then
+if [ $1 -eq 0 -a -d /usr/NextSpace/Preferences ]; then
   rm -rf /usr/NextSpace/Preferences
 fi
 


### PR DESCRIPTION
This PR fixes problems cleanly updating RPM packages:
- The old package's `%postun` section is executed after the new package has been installed. Hence it must not remove files unless it is executed in a clean uninstall.
- This had broken RPM updates for packages like `libcorefoundation` (shared libraries were missing after update).

Note that this fix will take effect only when RPMs containing it are upgraded. Hence in order to get things going people will need to first uninstall all NS RPMs and then install them (i.e. not updating them). Once that's done, subsequent RPM updates will work.

By the way, once the next version is released it will be worthwhile mentioning this in the release notes, because the last release still contained this problem. 