### PR TITLE
- Add Debian 13 dependency profile and update Debian runtime/build de…

### DIFF
--- a/OS/Linux/dot_hidden
+++ b/OS/Linux/dot_hidden
@@ -18,4 +18,7 @@ sys
 tmp
 usr
 var
-
+initrd.img
+initrd.img.old
+vmlinuz
+vmlinuz.old

--- a/Packaging/Sources/0_build_libdispatch.sh
+++ b/Packaging/Sources/0_build_libdispatch.sh
@@ -6,19 +6,18 @@
 # Install package dependecies
 #----------------------------------------
 ${ECHO} ">>> Installing ${OS_ID} packages for Grand Central Dispatch build"
-if [ "${OS_ID}" = "debian" ] || [ "${OS_ID}" = "ubuntu" ]; then
+if is_debian_like; then
 	${ECHO} "Debian-based Linux distribution: calling 'apt-get install'."
-	sudo apt-get install -q -y ${BUILD_TOOLS} ${RUNTIME_DEPS} || exit 1
+	install_apt_packages ${BUILD_TOOLS} ${RUNTIME_DEPS}
 else
 	if [ "${OS_ID}" = "fedora" ] || [ "$OS_ID" = "ultramarine" ]; then
 		${ECHO} "No need to build - installing 'libdispatch-devel' from Fedora repository..."
-		sudo dnf -y install libdispatch-devel || exit 1
+		install_rpm_packages libdispatch-devel
 		exit 0
 	fi
-	${ECHO} "RedHat-based Linux distribution: calling 'yum -y install'."
+	${ECHO} "RedHat-based Linux distribution: calling 'sudo ${RPM_PACKAGE_MANAGER} -y install'."
 	SPEC_FILE=${PROJECT_DIR}/Libraries/libdispatch/libdispatch.spec
-	DEPS=`rpmspec -q --buildrequires ${SPEC_FILE} | awk -c '{print $1}'`
-	sudo yum -y install ${DEPS} || exit 1
+	install_rpm_spec_buildrequires "${SPEC_FILE}"
 fi
 
 #----------------------------------------
@@ -27,26 +26,33 @@ fi
 GIT_PKG_NAME=swift-corelibs-libdispatch-swift-${libdispatch_version}-RELEASE
 
 if [ ! -d ${BUILD_ROOT}/${GIT_PKG_NAME} ]; then
-	curl -L https://github.com/apple/swift-corelibs-libdispatch/archive/swift-${libdispatch_version}-RELEASE.tar.gz -o ${BUILD_ROOT}/${GIT_PKG_NAME}.tar.gz
-	cd ${BUILD_ROOT}
-	tar zxf ${GIT_PKG_NAME}.tar.gz
-	cd ..
+	download_tarball_once \
+		"https://github.com/apple/swift-corelibs-libdispatch/archive/swift-${libdispatch_version}-RELEASE.tar.gz" \
+		"${BUILD_ROOT}/${GIT_PKG_NAME}.tar.gz" \
+		"${BUILD_ROOT}/${GIT_PKG_NAME}"
 fi
 
 #----------------------------------------
 # Build
 #----------------------------------------
 cd ${BUILD_ROOT}/${GIT_PKG_NAME} || exit 1
+if [ "${OS_ID}" = "debian" ] && [ "${OS_VERSION}" = "13" ]; then
+	${ECHO} "Patching libdispatch compiler warnings for Debian 13..."
+	find . -name 'CMakeLists.txt' -o -name '*.cmake' | xargs sed -i \
+		-e 's/-Werror=cast-function-type-mismatch//g' \
+		-e 's/-Werror //g' \
+		-e 's/ -Werror//g'
+fi
 rm -rf _build 2>/dev/null
 mkdir -p _build
 cd _build
 
-C_FLAGS="-Wno-error=unused-but-set-variable"
+C_FLAGS="-Wno-error=unused-but-set-variable -Wno-error=cast-function-type-mismatch -Wno-cast-function-type-mismatch"
 $CMAKE_CMD .. \
-	-DCMAKE_C_COMPILER=${C_COMPILER} \
-	-DCMAKE_CXX_COMPILER=${CXX_COMPILER} \
-	-DCMAKE_C_FLAGS=${C_FLAGS} \
-	-DCMAKE_CXX_FLAGS=${C_FLAGS} \
+	-DCMAKE_C_COMPILER="${C_COMPILER}" \
+	-DCMAKE_CXX_COMPILER="${CXX_COMPILER}" \
+	-DCMAKE_C_FLAGS="${C_FLAGS}" \
+	-DCMAKE_CXX_FLAGS="${C_FLAGS}" \
 	-DCMAKE_INSTALL_PREFIX=/usr/NextSpace \
 	-DCMAKE_INSTALL_LIBDIR=/usr/NextSpace/lib \
 	-DCMAKE_INSTALL_MANDIR=/usr/NextSpace/Documentation/man \
@@ -65,7 +71,7 @@ $MAKE_CMD
 # Install
 #----------------------------------------
 #sudo $MAKE_CMD install
-$INSTALL_CMD
+run_install
 
 #----------------------------------------
 # Postinstall
@@ -85,6 +91,4 @@ $MV_CMD libdispatch.so libdispatch.so.${libdispatch_version}
 $LN_CMD libdispatch.so.${libdispatch_version} libdispatch.so.${SHORT_VER}
 $LN_CMD libdispatch.so.${libdispatch_version} libdispatch.so
 
-if [ "$DEST_DIR" = "" ]; then
-	sudo ldconfig
-fi
+refresh_ldconfig

--- a/Packaging/Sources/1_build_libcorefoundation.sh
+++ b/Packaging/Sources/1_build_libcorefoundation.sh
@@ -6,15 +6,15 @@
 # Install package dependecies
 #----------------------------------------
 ${ECHO} ">>> Installing ${OS_ID} packages for CoreFoundation library build"
-if [ ${OS_ID} = "debian" ] || [ ${OS_ID} = "ubuntu" ]; then
+if is_debian_like; then
 	${ECHO} "Debian-based Linux distribution: calling 'apt-get install'."
-	sudo apt-get install -y ${RUNTIME_DEPS} || exit 1
+	install_apt_packages ${RUNTIME_DEPS}
 else
 	${ECHO} ">>> Installing ${OS_ID} packages for CoreFoundation build"
-	${ECHO} "RedHat-based Linux distribution: calling 'yum -y install'."
+	${ECHO} "RedHat-based Linux distribution: calling 'sudo ${RPM_PACKAGE_MANAGER} -y install'."
 	SPEC_FILE=${PROJECT_DIR}/Packaging/RedHat/SPECS/libcorefoundation.spec
-	DEPS=`rpmspec -q --buildrequires ${SPEC_FILE} | awk -c '{print $1}'`
-	sudo yum -y install ${DEPS} git || exit 1
+	install_rpm_spec_buildrequires "${SPEC_FILE}"
+	install_rpm_packages git
 fi
 
 #----------------------------------------
@@ -28,6 +28,27 @@ if [ ! -d ${BUILD_ROOT}/${CF_PKG_NAME} ]; then
 fi
 if [ ! -d ${BUILD_ROOT}/${CFNET_PKG_NAME} ]; then
     git clone --depth 1 https://github.com/trunkmaster/apple-cfnetwork ${BUILD_ROOT}/${CFNET_PKG_NAME}
+fi
+
+CF_COMPAT_FILE="${BUILD_ROOT}/${CF_PKG_NAME}/CFThreadSetNameCompat.c"
+if [ ! -f "${CF_COMPAT_FILE}" ]; then
+	${ECHO} "Adding CoreFoundation _CFThreadSetName compatibility source..."
+	cat > "${CF_COMPAT_FILE}" <<'EOF'
+#if defined(__linux__)
+__attribute__((weak)) int _CFThreadSetName(void *thread, const char *name)
+{
+    (void)thread;
+    (void)name;
+    return 0;
+}
+#endif
+EOF
+fi
+
+CF_CMAKE_FILE=`grep -rl "CFPlatform.c" "${BUILD_ROOT}/${CF_PKG_NAME}" --include 'CMakeLists.txt' | head -n 1`
+if [ -n "${CF_CMAKE_FILE}" ] && ! grep "CFThreadSetNameCompat.c" "${CF_CMAKE_FILE}" >/dev/null 2>&1; then
+	${ECHO} "Adding CoreFoundation _CFThreadSetName compatibility source to CMake..."
+	sed -i 's/CFPlatform\.c/CFPlatform.c CFThreadSetNameCompat.c/' "${CF_CMAKE_FILE}"
 fi
 
 #----------------------------------------
@@ -54,6 +75,11 @@ $CMAKE_CMD .. \
 	|| exit 1
 
 $MAKE_CMD || exit 1
+CF_BUILD_LIB=`find . -name 'libCoreFoundation.so*' -type f | head -n 1`
+if [ -n "${CF_BUILD_LIB}" ] && nm -D "${CF_BUILD_LIB}" | grep " U _CFThreadSetName" >/dev/null 2>&1; then
+	print_ERR "Built CoreFoundation still has undefined _CFThreadSetName."
+	exit 1
+fi
 
 # CFNetwork
 if [ -n  "$libcfnetwork_version" ]; then
@@ -62,10 +88,10 @@ if [ -n  "$libcfnetwork_version" ]; then
 	mkdir -p .build
 	cd .build
 	CFN_CFLAGS="-F../../${CF_PKG_NAME}/.build -I/usr/NextSpace/include"
-	CFN_LD_FLAGS="-L/usr/NextSpace/lib -L../../${CF_PKG_NAME}/.build/CoreFoundation.framework"
+	CFN_LD_FLAGS="-L../../${CF_PKG_NAME}/.build/CoreFoundation.framework -L/usr/NextSpace/lib"
 	cmake .. \
 		-DCMAKE_C_COMPILER=${C_COMPILER} \
-		-DCMAKE_CXX_COMPILER=clang++ \
+		-DCMAKE_CXX_COMPILER=${CXX_COMPILER} \
 		-DCFNETWORK_CFLAGS="${CFN_CFLAGS}" \
 		-DCFNETWORK_LDLAGS="${CFN_LD_FLAGS}" \
 		-DBUILD_SHARED_LIBS=YES \
@@ -83,7 +109,7 @@ fi
 
 ### CoreFoundation
 cd ${BUILD_ROOT}/${CF_PKG_NAME}/.build || exit 1
-$INSTALL_CMD
+run_install
 
 CF_DIR=${DEST_DIR}/usr/NextSpace/Frameworks/CoreFoundation.framework
 
@@ -106,7 +132,7 @@ $LN_CMD ../Frameworks/CoreFoundation.framework/Versions/${libcorefoundation_vers
 ### CFNetwork
 if [ -n  "$libcfnetwork_version" ]; then
 	cd ${BUILD_ROOT}/${CFNET_PKG_NAME}/.build || exit 1
-	$INSTALL_CMD
+	run_install
 
 	CFNET_DIR=${DEST_DIR}/usr/NextSpace/Frameworks/CFNetwork.framework
 
@@ -127,6 +153,4 @@ if [ -n  "$libcfnetwork_version" ]; then
 	$LN_CMD ../Frameworks/CFNetwork.framework/Versions/${libcfnetwork_version}/libCFNetwork.so* ./
 fi
 
-if [ "$DEST_DIR" = "" ]; then
-	sudo ldconfig
-fi
+refresh_ldconfig

--- a/Packaging/Sources/2_build_libobjc2.sh
+++ b/Packaging/Sources/2_build_libobjc2.sh
@@ -5,12 +5,11 @@
 #----------------------------------------
 # Install package dependecies
 #----------------------------------------
-if [ ${OS_ID} != "debian" ] && [ ${OS_ID} != "ubuntu" ]; then
+if is_rpm_like; then
 	${ECHO} ">>> Installing ${OS_ID} packages for ObjC 2.0 runtime build"
-	${ECHO} "RedHat-based Linux distribution: calling 'yum -y install'."
+	${ECHO} "RedHat-based Linux distribution: calling 'sudo ${RPM_PACKAGE_MANAGER} -y install'."
 	SPEC_FILE=${PROJECT_DIR}/Packaging/RedHat/SPECS/libobjc2.spec
-	DEPS=`rpmspec -q --buildrequires ${SPEC_FILE} | grep -v "libdispatch-devel" | awk -c '{print $1}'`
-	sudo yum -y install ${DEPS} || exit 1
+	install_rpm_spec_buildrequires "${SPEC_FILE}" "libdispatch-devel"
 fi
 
 #----------------------------------------
@@ -24,7 +23,7 @@ if [ ! -d ${BUILD_ROOT}/libobjc2-${libobjc2_version} ]; then
 	curl -L https://github.com/gnustep/libobjc2/archive/v${libobjc2_version}.tar.gz -o ${BUILD_ROOT}/libobjc2-${libobjc2_version}.tar.gz
 	curl -L https://github.com/Tessil/robin-map/archive/${ROBIN_MAP_PKG_NAME} -o ${BUILD_ROOT}/libobjc2_robin-map.tar.gz
 
-	cd ${BUILD_ROOT}
+	cd "${BUILD_ROOT}" || exit 1
 	tar zxf libobjc2-${libobjc2_version}.tar.gz
 	tar zxf libobjc2_robin-map.tar.gz
 fi
@@ -54,7 +53,7 @@ $CMAKE_CMD .. \
 	-DCMAKE_LIBRARY_PATH=/usr/NextSpace/lib \
 	-DCMAKE_INSTALL_LIBDIR=lib \
 	-DCMAKE_INSTALL_PREFIX=/usr/NextSpace \
-	-DCMAKE_MODULE_LINKER_FLAGS="-fuse-ld=/usr/bin/ld.gold -Wl,-rpath,/usr/NextSpace/lib" \
+	-DCMAKE_MODULE_LINKER_FLAGS="${LD_GOLD_FLAG} -Wl,-rpath,/usr/NextSpace/lib" \
 	-DCMAKE_SKIP_RPATH=ON \
 	-DTESTS=OFF \
 	-DCMAKE_BUILD_TYPE=Release \
@@ -70,12 +69,10 @@ $MAKE_CMD
 if [ -f $DEST_DIR/usr/NextSpace/include/Block.h ]; then
 	$MV_CMD $DEST_DIR/usr/NextSpace/include/Block.h $DEST_DIR/usr/NextSpace/include/Block-libdispatch.h
 fi
-$INSTALL_CMD || exit 1
+run_install || exit 1
 if [ -f $DEST_DIR/usr/NextSpace/include/Block-libdispatch.h ]; then
 	$MV_CMD $DEST_DIR/usr/NextSpace/include/Block.h $DEST_DIR/usr/NextSpace/include/Block-libobjc.h
 	$MV_CMD $DEST_DIR/usr/NextSpace/include/Block-libdispatch.h $DEST_DIR/usr/NextSpace/include/Block.h
 fi
 
-if [ "$DEST_DIR" = "" ]; then
-	sudo ldconfig
-fi
+refresh_ldconfig

--- a/Packaging/Sources/3_build_core.sh
+++ b/Packaging/Sources/3_build_core.sh
@@ -3,63 +3,120 @@
 . ../environment.sh
 
 #----------------------------------------
+# Install package dependecies
+#----------------------------------------
+if is_debian_like; then
+	install_apt_packages ${RUNTIME_RUN_DEPS} ${GNUSTEP_MAKE_DEPS}
+else
+	SPEC_FILE=${PROJECT_DIR}/Packaging/RedHat/SPECS/nextspace-core.spec
+	install_rpm_spec_requires "${SPEC_FILE}" "libobjc2" "libdispatch" "nextspace-core" "git" "clang"
+fi
+
+#----------------------------------------
 # Install system configuration files
 #----------------------------------------
 CORE_SOURCES=${PROJECT_DIR}/OS/Linux
 
+if [ ! -d "${CORE_SOURCES}" ]; then
+	$ECHO "\033[31mERROR: Missing core resources directory: ${CORE_SOURCES}\033[0m"
+	exit 1
+fi
+
+$ECHO "Populating /etc... /usr..."
+
 # /.hidden
-$CP_CMD ${CORE_SOURCES}/dot_hidden /.hidden
+if [ -f "${CORE_SOURCES}/dot_hidden" ]; then
+	$CP_CMD "${CORE_SOURCES}/dot_hidden" /.hidden
+fi
 
 # Preferences
+# The source tree keeps user defaults under /etc/skel. Do not install global
+# /Library/Preferences here; the clean project leaves this disabled.
 #$MKDIR_CMD $DEST_DIR/Library/Preferences
-#$CP_CMD ${CORE_SOURCES}/Library/Preferences/* $DEST_DIR/Library/Preferences/
+#$CP_CMD "${CORE_SOURCES}"/Library/Preferences/* $DEST_DIR/Library/Preferences/
 
 # Linker cache
-if ! [ -d $DEST_DIR/etc/ld.so.conf.d ];then
-	$MKDIR_CMD -v $DEST_DIR/etc/ld.so.conf.d
+if [ -f "${CORE_SOURCES}/etc/ld.so.conf.d/nextspace.conf" ]; then
+	if ! [ -d $DEST_DIR/etc/ld.so.conf.d ]; then
+		$MKDIR_CMD -v $DEST_DIR/etc/ld.so.conf.d
+	fi
+	$CP_CMD -v "${CORE_SOURCES}/etc/ld.so.conf.d/nextspace.conf" $DEST_DIR/etc/ld.so.conf.d/
+	refresh_ldconfig
 fi
-$CP_CMD -v ${CORE_SOURCES}/etc/ld.so.conf.d/nextspace.conf $DEST_DIR/etc/ld.so.conf.d/
-sudo ldconfig
 
 # X11
-$CP_CMD ${CORE_SOURCES}/etc/X11/Xresources.nextspace $DEST_DIR/etc/X11
+if [ -f "${CORE_SOURCES}/etc/X11/Xresources.nextspace" ]; then
+	if ! [ -d $DEST_DIR/etc/X11 ]; then
+		$MKDIR_CMD -v $DEST_DIR/etc/X11
+	fi
+	$CP_CMD "${CORE_SOURCES}/etc/X11/Xresources.nextspace" $DEST_DIR/etc/X11
+fi
+if [ -d "${CORE_SOURCES}/etc/X11/xorg.conf.d" ]; then
+	if ! [ -d $DEST_DIR/etc/X11/xorg.conf.d ]; then
+		$MKDIR_CMD -v $DEST_DIR/etc/X11/xorg.conf.d
+	fi
+	$CP_CMD "${CORE_SOURCES}"/etc/X11/xorg.conf.d/*.conf $DEST_DIR/etc/X11/xorg.conf.d/
+fi
 
 # PolKit & udev
-if ! [ -d $DEST_DIR/etc/polkit-1/rules.d ];then
-	$MKDIR_CMD -v $DEST_DIR/etc/polkit-1/rules.d
+if [ -d "${CORE_SOURCES}/etc/polkit-1/rules.d" ]; then
+	if ! [ -d $DEST_DIR/etc/polkit-1/rules.d ]; then
+		$MKDIR_CMD -v $DEST_DIR/etc/polkit-1/rules.d
+	fi
+	$CP_CMD "${CORE_SOURCES}"/etc/polkit-1/rules.d/*.rules $DEST_DIR/etc/polkit-1/rules.d/
 fi
-#$CP_CMD ${CORE_SOURCES}/etc/polkit-1/rules.d/*.rules $DEST_DIR/etc/polkit-1/rules.d/
-#if ! [ -d $DEST_DIR/etc/udev/rules.d ];then
-#	$MKDIR_CMD -v $DEST_DIR/etc/udev/rules.d
-#fi
-#$CP_CMD ${CORE_SOURCES}/etc/udev/rules.d/*.rules $DEST_DIR/etc/udev/rules.d/
+if [ -d "${CORE_SOURCES}/etc/udev/rules.d" ]; then
+	if ! [ -d $DEST_DIR/etc/udev/rules.d ]; then
+		$MKDIR_CMD -v $DEST_DIR/etc/udev/rules.d
+	fi
+	$CP_CMD "${CORE_SOURCES}"/etc/udev/rules.d/*.rules $DEST_DIR/etc/udev/rules.d/
+fi
 
 # User environment
-if ! [ -d $DEST_DIR/etc/profile.d ];then
-	$MKDIR_CMD -v $DEST_DIR/etc/profile.d
+if [ -f "${CORE_SOURCES}/etc/profile.d/nextspace.sh" ]; then
+	if ! [ -d $DEST_DIR/etc/profile.d ]; then
+		$MKDIR_CMD -v $DEST_DIR/etc/profile.d
+	fi
+	$CP_CMD "${CORE_SOURCES}/etc/profile.d/nextspace.sh" $DEST_DIR/etc/profile.d/
 fi
-$CP_CMD ${CORE_SOURCES}/etc/profile.d/nextspace.sh $DEST_DIR/etc/profile.d/
 
-if ! [ -d $DEST_DIR/etc/skel ];then
-	$MKDIR_CMD -v $DEST_DIR/etc/skel
+if [ -d "${CORE_SOURCES}/etc/skel" ]; then
+	if ! [ -d $DEST_DIR/etc/skel ]; then
+		$MKDIR_CMD -v $DEST_DIR/etc/skel
+	fi
+	[ -d "${CORE_SOURCES}/etc/skel/Library" ] && $CP_CMD "${CORE_SOURCES}"/etc/skel/Library $DEST_DIR/etc/skel/
+	[ -d "${CORE_SOURCES}/etc/skel/.config" ] && $CP_CMD "${CORE_SOURCES}"/etc/skel/.config $DEST_DIR/etc/skel/
+	[ -f "${CORE_SOURCES}/etc/skel/.gtkrc-2.0" ] && $CP_CMD "${CORE_SOURCES}"/etc/skel/.gtkrc-2.0 $DEST_DIR/etc/skel/
+	[ -f "${CORE_SOURCES}/etc/skel/.zshrc.nextspace" ] && $CP_CMD "${CORE_SOURCES}"/etc/skel/.zshrc.nextspace $DEST_DIR/etc/skel/
+	for nextspace_file in "${CORE_SOURCES}"/etc/skel/.*.nextspace; do
+		[ -f "$nextspace_file" ] && $CP_CMD "$nextspace_file" $DEST_DIR/etc/skel/
+	done
+
+	if [ "$DEST_DIR" = "" ] && [ -d /root ]; then
+		[ -d "${CORE_SOURCES}/etc/skel/.config" ] && $CP_CMD "${CORE_SOURCES}"/etc/skel/.config /root
+		[ -d "${CORE_SOURCES}/etc/skel/Library" ] && $CP_CMD "${CORE_SOURCES}"/etc/skel/Library /root
+	fi
 fi
-$CP_CMD ${CORE_SOURCES}/etc/skel/Library $DEST_DIR/etc/skel/
-$CP_CMD ${CORE_SOURCES}/etc/skel/.config $DEST_DIR/etc/skel/
-$CP_CMD ${CORE_SOURCES}/etc/skel/.gtkrc-2.0 $DEST_DIR/etc/skel/
-$CP_CMD ${CORE_SOURCES}/etc/skel/.*.nextspace $DEST_DIR/etc/skel/
-
-# /root
-$CP_CMD ${CORE_SOURCES}/etc/skel/.config /root
-$CP_CMD ${CORE_SOURCES}/etc/skel/Library /root
 
 # Scripts
-if ! [ -d $DEST_DIR/usr/NextSpace/bin ];then
-	$MKDIR_CMD -v $DEST_DIR/usr/NextSpace/bin
+if [ -d "${CORE_SOURCES}/usr/NextSpace/bin" ]; then
+	if ! [ -d $DEST_DIR/usr/NextSpace/bin ]; then
+		$MKDIR_CMD -v $DEST_DIR/usr/NextSpace/bin
+	fi
+	$CP_CMD "${CORE_SOURCES}"/usr/NextSpace/bin/* $DEST_DIR/usr/NextSpace/bin/
 fi
-$CP_CMD ${CORE_SOURCES}/usr/NextSpace/bin/* $DEST_DIR/usr/NextSpace/bin/
 
 # Icons, Plymouth resources and fontconfig configuration
-if ! [ -d $DEST_DIR/usr/share ];then
-	$MKDIR_CMD -v $DEST_DIR/usr/share
+if [ -d "${CORE_SOURCES}/usr/share" ]; then
+	if ! [ -d $DEST_DIR/usr/share ]; then
+		$MKDIR_CMD -v $DEST_DIR/usr/share
+	fi
+	$CP_CMD "${CORE_SOURCES}"/usr/share/* $DEST_DIR/usr/share/
 fi
-$CP_CMD ${CORE_SOURCES}/usr/share/* $DEST_DIR/usr/share/
+
+# Set the NEXTSPACE theme as the default for Plymouth
+if command -v plymouth-set-default-theme >/dev/null 2>&1; then
+	if [ ! "`plymouth-set-default-theme`" = "nextspace" ]; then
+		plymouth-set-default-theme -R nextspace
+	fi
+fi

--- a/Packaging/Sources/3_build_core.sh
+++ b/Packaging/Sources/3_build_core.sh
@@ -114,9 +114,5 @@ if [ -d "${CORE_SOURCES}/usr/share" ]; then
 	$CP_CMD "${CORE_SOURCES}"/usr/share/* $DEST_DIR/usr/share/
 fi
 
-# Set the NEXTSPACE theme as the default for Plymouth
-if command -v plymouth-set-default-theme >/dev/null 2>&1; then
-	if [ ! "`plymouth-set-default-theme`" = "nextspace" ]; then
-		plymouth-set-default-theme -R nextspace
-	fi
-fi
+# Set the NEXTSPACE theme as the default for Plymouth on live systems.
+configure_plymouth_theme nextspace || exit 1

--- a/Packaging/Sources/3_build_core.sh
+++ b/Packaging/Sources/3_build_core.sh
@@ -63,14 +63,14 @@ if [ -d "${CORE_SOURCES}/etc/polkit-1/rules.d" ]; then
 	if ! [ -d $DEST_DIR/etc/polkit-1/rules.d ]; then
 		$MKDIR_CMD -v $DEST_DIR/etc/polkit-1/rules.d
 	fi
-	$CP_CMD "${CORE_SOURCES}"/etc/polkit-1/rules.d/*.rules $DEST_DIR/etc/polkit-1/rules.d/
+#	$CP_CMD "${CORE_SOURCES}"/etc/polkit-1/rules.d/*.rules $DEST_DIR/etc/polkit-1/rules.d/
 fi
-if [ -d "${CORE_SOURCES}/etc/udev/rules.d" ]; then
-	if ! [ -d $DEST_DIR/etc/udev/rules.d ]; then
-		$MKDIR_CMD -v $DEST_DIR/etc/udev/rules.d
-	fi
-	$CP_CMD "${CORE_SOURCES}"/etc/udev/rules.d/*.rules $DEST_DIR/etc/udev/rules.d/
-fi
+#if [ -d "${CORE_SOURCES}/etc/udev/rules.d" ]; then
+#	if ! [ -d $DEST_DIR/etc/udev/rules.d ]; then
+#		$MKDIR_CMD -v $DEST_DIR/etc/udev/rules.d
+#	fi
+#	$CP_CMD "${CORE_SOURCES}"/etc/udev/rules.d/*.rules $DEST_DIR/etc/udev/rules.d/
+#fi
 
 # User environment
 if [ -f "${CORE_SOURCES}/etc/profile.d/nextspace.sh" ]; then

--- a/Packaging/Sources/3_build_tools-make.sh
+++ b/Packaging/Sources/3_build_tools-make.sh
@@ -6,14 +6,13 @@
 # Install package dependecies
 #----------------------------------------
 ${ECHO} ">>> Installing ${OS_ID} packages for GNUstep Make build"
-if [ ${OS_ID} = "debian" ] || [ ${OS_ID} = "ubuntu" ]; then
+if is_debian_like; then
 	${ECHO} "Debian-based Linux distribution: calling 'apt-get install'."
-	sudo apt-get install -y ${GNUSTEP_MAKE_DEPS} || exit 1
+	install_apt_packages ${GNUSTEP_MAKE_DEPS}
 else
-	${ECHO} "RedHat-based Linux distribution: calling 'yum -y install'."
+	${ECHO} "RedHat-based Linux distribution: calling 'sudo ${RPM_PACKAGE_MANAGER} -y install'."
 	SPEC_FILE=${PROJECT_DIR}/Packaging/RedHat/SPECS/nextspace-core.spec
-	DEPS=`rpmspec -q --buildrequires ${SPEC_FILE} | grep -v libobjc2 | grep -v "libdispatch-devel" | awk -c '{print $1}'`
-	sudo yum -y install ${DEPS} || exit 1
+	install_rpm_spec_buildrequires "${SPEC_FILE}" "libobjc2" "libdispatch-devel"
 fi
 
 #----------------------------------------
@@ -21,10 +20,10 @@ fi
 #----------------------------------------
 GIT_PKG_NAME=tools-make-make-${gnustep_make_version}
 if [ ! -d ${BUILD_ROOT}/${GIT_PKG_NAME} ]; then
-	curl -L https://github.com/gnustep/tools-make/archive/make-${gnustep_make_version}.tar.gz -o ${BUILD_ROOT}/${GIT_PKG_NAME}.tar.gz
-	cd ${BUILD_ROOT}
-	tar zxf ${GIT_PKG_NAME}.tar.gz || exit 1
-	cd ..
+	download_tarball_once \
+		"https://github.com/gnustep/tools-make/archive/make-${gnustep_make_version}.tar.gz" \
+		"${BUILD_ROOT}/${GIT_PKG_NAME}.tar.gz" \
+		"${BUILD_ROOT}/${GIT_PKG_NAME}"
 fi
 
 #----------------------------------------
@@ -51,5 +50,5 @@ cp ${PROJECT_DIR}/Libraries/gnustep/nextspace.fsl ${BUILD_ROOT}/tools-make-make-
 #----------------------------------------
 # Install
 #----------------------------------------
-$INSTALL_CMD || exit 1
+run_install || exit 1
 cd ${_PWD}

--- a/Packaging/Sources/4_build_libwraster.sh
+++ b/Packaging/Sources/4_build_libwraster.sh
@@ -7,14 +7,13 @@
 # Install package dependecies
 #----------------------------------------
 ${ECHO} ">>> Installing ${OS_ID} packages for WRaster library build"
-if [ ${OS_ID} = "debian" ] || [ ${OS_ID} = "ubuntu" ]; then
+if is_debian_like; then
 	${ECHO} "Debian-based Linux distribution: calling 'apt-get install'."
-	sudo apt-get install -y ${WRASTER_DEPS} || exit 1
+	install_apt_packages ${WRASTER_DEPS}
 else
-	${ECHO} "RedHat-based Linux distribution: calling 'yum -y install'."
+	${ECHO} "RedHat-based Linux distribution: calling 'sudo ${RPM_PACKAGE_MANAGER} -y install'."
 	SPEC_FILE=${PROJECT_DIR}/Packaging/RedHat/SPECS/libwraster.spec
-	DEPS=`rpmspec -q --buildrequires ${SPEC_FILE} | grep -v nextspace-core-devel | awk -c '{print $1}'`
-	sudo yum -y install ${DEPS} || exit 1
+	install_rpm_spec_buildrequires "${SPEC_FILE}" "nextspace-core-devel"
 fi
 
 
@@ -24,10 +23,7 @@ fi
 SOURCES_DIR=${PROJECT_DIR}/Libraries/libwraster
 BUILD_DIR=${BUILD_ROOT}/libwraster
 
-if [ -d ${BUILD_DIR} ]; then
-	rm -rf ${BUILD_DIR}
-fi
-cp -R ${SOURCES_DIR} ${BUILD_ROOT}
+copy_clean_build_tree "${SOURCES_DIR}" "${BUILD_DIR}"
 
 #----------------------------------------
 # Build
@@ -39,8 +35,6 @@ export CMAKE=${CMAKE_CMD}
 export QA_SKIP_BUILD_ROOT=1
 
 $MAKE_CMD || exit 1
-$INSTALL_CMD || exit 1
+run_install || exit 1
 
-if [ "$DEST_DIR" = "" ]; then
-	sudo ldconfig
-fi
+refresh_ldconfig

--- a/Packaging/Sources/5_build_libs-base.sh
+++ b/Packaging/Sources/5_build_libs-base.sh
@@ -8,14 +8,13 @@
 # Install package dependecies
 #----------------------------------------
 ${ECHO} ">>> Installing ${OS_ID} packages for GNUstep Base (Foundation) build"
-if [ ${OS_ID} = "debian" ] || [ ${OS_ID} = "ubuntu" ]; then
+if is_debian_like; then
 	${ECHO} "Debian-based Linux distribution: calling 'apt-get install'."
-	sudo apt-get install -y ${GNUSTEP_BASE_DEPS} || exit 1
+	install_apt_packages ${GNUSTEP_BASE_DEPS}
 else
-	${ECHO} "RedHat-based Linux distribution: calling 'yum -y install'."
+	${ECHO} "RedHat-based Linux distribution: calling 'sudo ${RPM_PACKAGE_MANAGER} -y install'."
 	SPEC_FILE=${PROJECT_DIR}/Packaging/RedHat/SPECS/nextspace-gnustep.spec
-	DEPS=`rpmspec -q --buildrequires ${SPEC_FILE} | grep -v libobjc2 | awk -c '{print $1}'`
-	sudo yum -y install ${DEPS} || exit 1
+	install_rpm_spec_buildrequires "${SPEC_FILE}" "libobjc2"
 fi
 
 #----------------------------------------
@@ -24,10 +23,10 @@ fi
 GIT_PKG_NAME=libs-base-base-${gnustep_base_version}
 
 if [ ! -d ${BUILD_ROOT}/${GIT_PKG_NAME} ]; then
-	curl -L https://github.com/gnustep/libs-base/archive/base-${gnustep_base_version}.tar.gz -o ${BUILD_ROOT}/${GIT_PKG_NAME}.tar.gz
-	cd ${BUILD_ROOT}
-	tar zxf ${GIT_PKG_NAME}.tar.gz || exit 1
-	cd ..
+	download_tarball_once \
+		"https://github.com/gnustep/libs-base/archive/base-${gnustep_base_version}.tar.gz" \
+		"${BUILD_ROOT}/${GIT_PKG_NAME}.tar.gz" \
+		"${BUILD_ROOT}/${GIT_PKG_NAME}"
 fi
 
 #----------------------------------------
@@ -43,7 +42,7 @@ $MAKE_CMD || exit 1
 #----------------------------------------
 # Install
 #----------------------------------------
-$INSTALL_CMD
+run_install
 cd ${_PWD}
 
 #----------------------------------------
@@ -59,10 +58,9 @@ $CP_CMD ${SOURCES_DIR}/gdnc.service $DEST_DIR/usr/NextSpace/lib/systemd
 $CP_CMD ${SOURCES_DIR}/gdnc-local.service $DEST_DIR/usr/NextSpace/lib/systemd
 
 if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true" ]; then
-	sudo ldconfig
-	sudo systemctl daemon-reload
-	systemctl status gdomap || sudo systemctl enable /usr/NextSpace/lib/systemd/gdomap.service;
-	systemctl status gdnc || sudo systemctl enable /usr/NextSpace/lib/systemd/gdnc.service;
-	sudo systemctl enable /usr/NextSpace/lib/systemd/gdnc-local.service;
-	sudo systemctl start gdomap gdnc
+	refresh_ldconfig
+	reload_systemd_if_live
+	enable_service_once gdomap /usr/NextSpace/lib/systemd/gdomap.service
+	enable_service_once gdnc /usr/NextSpace/lib/systemd/gdnc.service
+	enable_service_once gdnc-local /usr/NextSpace/lib/systemd/gdnc-local.service
 fi

--- a/Packaging/Sources/5_build_libs-base.sh
+++ b/Packaging/Sources/5_build_libs-base.sh
@@ -57,7 +57,7 @@ $CP_CMD ${SOURCES_DIR}/gdomap.service $DEST_DIR/usr/NextSpace/lib/systemd
 $CP_CMD ${SOURCES_DIR}/gdnc.service $DEST_DIR/usr/NextSpace/lib/systemd
 $CP_CMD ${SOURCES_DIR}/gdnc-local.service $DEST_DIR/usr/NextSpace/lib/systemd
 
-if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true" ]; then
+if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true" ] && [ "$CI" != "true" ]; then
 	refresh_ldconfig
 	reload_systemd_if_live
 	enable_service_once gdomap /usr/NextSpace/lib/systemd/gdomap.service

--- a/Packaging/Sources/6_build_libs-gui.sh
+++ b/Packaging/Sources/6_build_libs-gui.sh
@@ -84,7 +84,7 @@ $CP_CMD ${SOURCES_DIR}/GlobalDefaults.plist $DEST_DIR/Library/Preferences || exi
 #----------------------------------------
 $CP_CMD ${SOURCES_DIR}/gpbs.service $DEST_DIR/usr/NextSpace/lib/systemd || exit 1
 
-if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true" ]; then
+if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true" ] && [ "$CI" != "true" ]; then
 	refresh_ldconfig
 	reload_systemd_if_live
 	enable_service_once gpbs /usr/NextSpace/lib/systemd/gpbs.service

--- a/Packaging/Sources/6_build_libs-gui.sh
+++ b/Packaging/Sources/6_build_libs-gui.sh
@@ -7,9 +7,9 @@
 #----------------------------------------
 # Install package dependecies
 #----------------------------------------
-if [ ${OS_ID} = "debian" ] || [ ${OS_ID} = "ubuntu" ]; then
+if is_debian_like; then
   	${ECHO} ">>> Installing packages for GNUstep GUI (AppKit) build"
-	sudo apt-get install -q -y ${GNUSTEP_GUI_DEPS}
+	install_apt_packages ${GNUSTEP_GUI_DEPS}
 fi
 
 #----------------------------------------
@@ -19,9 +19,10 @@ GIT_PKG_NAME=libs-gui-gui-${gnustep_gui_version}
 SOURCES_DIR=${PROJECT_DIR}/Libraries/gnustep
 
 if [ ! -d ${BUILD_ROOT}/${GIT_PKG_NAME} ]; then
-	curl -L https://github.com/gnustep/libs-gui/archive/gui-${gnustep_gui_version}.tar.gz -o ${BUILD_ROOT}/${GIT_PKG_NAME}.tar.gz
-	cd ${BUILD_ROOT}
-	tar zxf ${GIT_PKG_NAME}.tar.gz || exit 1
+	download_tarball_once \
+		"https://github.com/gnustep/libs-gui/archive/gui-${gnustep_gui_version}.tar.gz" \
+		"${BUILD_ROOT}/${GIT_PKG_NAME}.tar.gz" \
+		"${BUILD_ROOT}/${GIT_PKG_NAME}"
 	# Patches
 	cd ${BUILD_ROOT}/${GIT_PKG_NAME}
 	patch -p1 < ${SOURCES_DIR}/libs-gui_NSApplication.patch
@@ -38,7 +39,7 @@ cd ${BUILD_ROOT}/${GIT_PKG_NAME} || exit 1
 if [ -d obj ]; then
 	$MAKE_CMD clean
 fi
-if [ ${OS_ID} = "debian" ] || [ ${OS_ID} = "ubuntu" ]; then
+if is_debian_like; then
 	./configure --disable-icu-config || exit 1
 else
 	./configure || exit 1
@@ -48,7 +49,7 @@ $MAKE_CMD || exit 1
 #----------------------------------------
 # Install
 #----------------------------------------
-$INSTALL_CMD || exit 1
+run_install || exit 1
 # libwraster crashes on loading default GNUstep common_Tile.tiff.
 # Replace it in case when NextSpace theme will be disabled.
 print_H2 "Replacing /Library/Images/common_Tile.tiff..."
@@ -60,17 +61,14 @@ $CP_CMD -f -v ${SOURCES_DIR}/nextspace-theme/Resources/ThemeImages/common_Tile.t
 THEME_SOURCES_DIR=${SOURCES_DIR}/nextspace-theme
 BUILD_DIR=${BUILD_ROOT}/nextspace-theme
 
-if [ -d ${BUILD_DIR} ]; then
-	rm -rf ${BUILD_DIR} || exit 1
-fi
-cp -R ${THEME_SOURCES_DIR} ${BUILD_ROOT} || exit 1
+copy_clean_build_tree "${THEME_SOURCES_DIR}" "${BUILD_DIR}"
 
 #----------------------------------------
 # Build and install theme
 #----------------------------------------
 cd ${BUILD_DIR} || exit 1
 $MAKE_CMD || exit 1
-$INSTALL_CMD || exit 1
+run_install || exit 1
 
 #----------------------------------------
 # Install global defaults
@@ -87,7 +85,7 @@ $CP_CMD ${SOURCES_DIR}/GlobalDefaults.plist $DEST_DIR/Library/Preferences || exi
 $CP_CMD ${SOURCES_DIR}/gpbs.service $DEST_DIR/usr/NextSpace/lib/systemd || exit 1
 
 if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true" ]; then
-	sudo ldconfig
-	sudo systemctl daemon-reload || exit 1
-	systemctl status gpbs || sudo systemctl enable /usr/NextSpace/lib/systemd/gpbs.service;
+	refresh_ldconfig
+	reload_systemd_if_live
+	enable_service_once gpbs /usr/NextSpace/lib/systemd/gpbs.service
 fi

--- a/Packaging/Sources/7_build_libs-back.sh
+++ b/Packaging/Sources/7_build_libs-back.sh
@@ -6,9 +6,9 @@
 #----------------------------------------
 # Install package dependecies
 #----------------------------------------
-if [ ${OS_ID} = "debian" ] || [ ${OS_ID} = "ubuntu" ]; then
+if is_debian_like; then
 	${ECHO} ">>> Installing packages for GNUstep GUI Backend build"
-	sudo apt-get install -y ${BACK_ART_DEPS}
+	install_apt_packages ${BACK_ART_DEPS}
 fi
 
 #----------------------------------------
@@ -17,10 +17,7 @@ fi
 SOURCES_DIR=${PROJECT_DIR}/Libraries/gnustep
 BUILD_DIR=${BUILD_ROOT}/back
 
-if [ -d ${BUILD_DIR} ]; then
-	rm -rf ${BUILD_DIR}
-fi
-cp -R ${SOURCES_DIR}/back ${BUILD_ROOT}
+copy_clean_build_tree "${SOURCES_DIR}/back" "${BUILD_DIR}"
 
 #----------------------------------------
 # Build and install
@@ -31,25 +28,25 @@ cd ${BUILD_DIR}
 # ART
 $MAKE_CMD clean || exit 1
 ./configure \
+	--enable-server=x11 \
 	--enable-graphics=art \
 	--with-name=art \
 	|| exit 1
 
 $MAKE_CMD || exit 1
-$INSTALL_CMD fonts=no || exit 1
+run_install fonts=no || exit 1
 
 # Cairo
 $MAKE_CMD clean || exit 1
 ./configure \
+	--enable-server=x11 \
 	--enable-graphics=cairo \
 	--with-name=cairo \
 	|| exit 1
 $MAKE_CMD || exit 1
-$INSTALL_CMD fonts=no || exit 1
+run_install fonts=no || exit 1
 
 #----------------------------------------
 # Post install
 #----------------------------------------
-if [ "$DEST_DIR" = "" ]; then
-	sudo ldconfig
-fi
+refresh_ldconfig

--- a/Packaging/Sources/8_build_Frameworks.sh
+++ b/Packaging/Sources/8_build_Frameworks.sh
@@ -7,17 +7,15 @@
 # Install package dependecies
 #----------------------------------------
 ${ECHO} ">>> Installing ${OS_ID} packages for NextSpace frameworks build"
-if [ ${OS_ID} = "debian" ] || [ ${OS_ID} = "ubuntu" ]; then
+if is_debian_like; then
 	${ECHO} "Debian-based Linux distribution: calling 'apt-get install'."
-	sudo apt-get install -y ${FRAMEWORKS_BUILD_DEPS}
-	sudo apt-get install -y ${FRAMEWORKS_RUN_DEPS}
+	install_apt_packages ${FRAMEWORKS_BUILD_DEPS}
+	install_apt_packages ${FRAMEWORKS_RUN_DEPS}
 else
-	${ECHO} "RedHat-based Linux distribution: calling 'yum -y install'."
+	${ECHO} "RedHat-based Linux distribution: calling 'sudo ${RPM_PACKAGE_MANAGER} -y install'."
 	SPEC_FILE=${PROJECT_DIR}/Packaging/RedHat/SPECS/nextspace-frameworks.spec
-	DEPS=`rpmspec -q --buildrequires ${SPEC_FILE} | grep -v "nextspace" | awk -c '{print $1}'`
-	sudo yum -y install ${DEPS} || exit 1
-	DEPS=`rpmspec -q --requires ${SPEC_FILE} | grep -v corefoundation | grep -v nextspace | awk -c '{print $1}'`
-	sudo yum -y install ${DEPS} || exit 1
+	install_rpm_spec_buildrequires "${SPEC_FILE}" "nextspace"
+	install_rpm_spec_requires "${SPEC_FILE}" "corefoundation" "nextspace"
 fi
 
 #----------------------------------------
@@ -26,10 +24,7 @@ fi
 SOURCES_DIR=${PROJECT_DIR}/Frameworks
 BUILD_DIR=${BUILD_ROOT}/Frameworks
 
-if [ -d ${BUILD_DIR} ]; then
-	rm -rf ${BUILD_DIR}
-fi
-cp -R ${SOURCES_DIR} ${BUILD_ROOT}
+copy_clean_build_tree "${SOURCES_DIR}" "${BUILD_DIR}"
 
 #----------------------------------------
 # Build
@@ -43,8 +38,8 @@ $MAKE_CMD || exit 1
 #----------------------------------------
 # Install
 #----------------------------------------
-$INSTALL_CMD
+run_install
 if [ "$DEST_DIR" = "" ]; then
-	sudo ldconfig
+	refresh_ldconfig
 	$LN_CMD /usr/NextSpace/Frameworks/DesktopKit.framework/Resources/25-nextspace-fonts.conf /etc/fonts/conf.d/25-nextspace-fonts.conf
 fi

--- a/Packaging/Sources/9_build_Applications.sh
+++ b/Packaging/Sources/9_build_Applications.sh
@@ -9,17 +9,15 @@ _PWD=`pwd`
 # Install package dependecies
 #----------------------------------------
 ${ECHO} ">>> Installing ${OS_ID} packages for NextSpace applications build"
-if [ ${OS_ID} = "debian" ] || [ ${OS_ID} = "ubuntu" ]; then
+if is_debian_like; then
 	${ECHO} "Debian-based Linux distribution: calling 'apt-get install'."
-	sudo apt-get install -y ${APPS_BUILD_DEPS}
-	sudo apt-get install -y ${APPS_RUN_DEPS}
+	install_apt_packages ${APPS_BUILD_DEPS}
+	install_apt_packages ${APPS_RUN_DEPS}
 else
-	${ECHO} "RedHat-based Linux distribution: calling 'yum -y install'."
+	${ECHO} "RedHat-based Linux distribution: calling 'sudo ${RPM_PACKAGE_MANAGER} -y install'."
 	SPEC_FILE=${PROJECT_DIR}/Packaging/RedHat/SPECS/nextspace-applications.spec
-	DEPS=`rpmspec -q --buildrequires ${SPEC_FILE} | grep -v "nextspace" | grep -v "corefoundation" | awk -c '{print $1}'`
-	sudo yum -y install ${DEPS} || exit 1
-	DEPS=`rpmspec -q --requires ${SPEC_FILE} | grep -v corefoundation | grep -v nextspace`
-	sudo yum -y install ${DEPS} || exit 1
+	install_rpm_spec_buildrequires "${SPEC_FILE}" "nextspace" "corefoundation"
+	install_rpm_spec_requires "${SPEC_FILE}" "corefoundation" "nextspace"
 fi
 
 #----------------------------------------
@@ -30,21 +28,14 @@ APP_BUILD_DIR=${BUILD_ROOT}/Applications
 GORM_BUILD_DIR=${BUILD_ROOT}/gorm-${gorm_version}
 PC_BUILD_DIR=${BUILD_ROOT}/projectcenter-${projectcenter_version}
 
-if [ -d ${APP_BUILD_DIR} ]; then
-	sudo rm -rf ${APP_BUILD_DIR}
-fi
-cp -R ${SOURCES_DIR}/Applications ${BUILD_ROOT}
+copy_clean_build_tree "${SOURCES_DIR}/Applications" "${APP_BUILD_DIR}"
 
 # GORM
-if [ -d ${GORM_BUILD_DIR} ]; then
-	sudo rm -rf ${GORM_BUILD_DIR}
-fi
+rm -rf "${GORM_BUILD_DIR}" 2>/dev/null
 git_remote_archive https://github.com/gnustep/apps-gorm ${GORM_BUILD_DIR} gorm-${gorm_version}
 
 # ProjectCenter
-if [ -d ${PC_BUILD_DIR} ]; then
-	sudo rm -rf ${PC_BUILD_DIR}
-fi
+rm -rf "${PC_BUILD_DIR}" 2>/dev/null
 git_remote_archive https://github.com/gnustep/apps-projectcenter ${PC_BUILD_DIR} projectcenter-${projectcenter_version}
 
 #----------------------------------------
@@ -57,22 +48,22 @@ export CC=${C_COMPILER}
 export CMAKE=${CMAKE_CMD}
 $MAKE_CMD clean
 $MAKE_CMD || exit 1
-$INSTALL_CMD || exit
+run_install || exit
 
 export GNUSTEP_INSTALLATION_DOMAIN=NETWORK
 cd ${GORM_BUILD_DIR}
 tar zxf ${SOURCES_DIR}/Libraries/gnustep/gorm-images.tar.gz
 patch -p1 < ${SOURCES_DIR}/Libraries/gnustep/gorm.patch
 $MAKE_CMD
-$INSTALL_CMD || exit
+run_install || exit
 
 cd ${PC_BUILD_DIR}
 tar zxf ${SOURCES_DIR}/Libraries/gnustep/projectcenter-images.tar.gz
 patch -p1 < ${SOURCES_DIR}/Libraries/gnustep/pc.patch
 $MAKE_CMD
-$INSTALL_CMD || exit
+run_install || exit
 
-sudo ldconfig
+refresh_ldconfig
 
 #----------------------------------------
 # Post install
@@ -109,7 +100,7 @@ if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true" ]; then
 	if [ -f /etc/selinux/config ]; then
 		SELINUX_STATE=`grep "^SELINUX=.*" /etc/selinux/config | awk -F= '{print $2}'`
 		if [ "${SELINUX_STATE}" != "disabled" ]; then
-			${ECHO} -n "SELinux enabled - dissabling it..."
+			${ECHO_N} "SELinux enabled - dissabling it..."
 			sudo sed -i -e ' s/SELINUX=.*/SELINUX=disabled/' /etc/selinux/config
 			${ECHO} "done"
 			${ECHO} "Please reboot to apply changes."

--- a/Packaging/Sources/9_build_Applications.sh
+++ b/Packaging/Sources/9_build_Applications.sh
@@ -68,7 +68,7 @@ refresh_ldconfig
 #----------------------------------------
 # Post install
 #----------------------------------------
-if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true" ]; then
+if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true" ] && [ "$CI" != "true" ]; then
 	# Login
 	systemctl --quiet is-active loginwindow.service
 	if [ $? -eq 0 ];then

--- a/Packaging/Sources/debian-12.deps.sh
+++ b/Packaging/Sources/debian-12.deps.sh
@@ -1,15 +1,21 @@
 # Works for Debian 12 and Ubuntu 22.04
 
+APT_INSTALL_OPTIONS="-y -o Dpkg::Progress-Fancy=1"
+
 BUILD_TOOLS="
     curl
     clang
+    binutils
     cmake
     git
+    pkg-config
 "
 #--- libdispatch, libcorefoundation, libobjc2
 RUNTIME_DEPS="
     libbsd-dev
     uuid-dev
+    libxml2-dev
+    libicu-dev
     libcurl4-gnutls-dev
     libavahi-compat-libdnssd-dev
 "
@@ -83,17 +89,27 @@ GNUSTEP_GUI_RUN_DEPS="
 #--- back-art
 BACK_ART_DEPS="
     libart-2.0-dev
+    libcairo2-dev
+    libfontconfig1-dev
     libfreetype-dev
+    libgl-dev
     libxcursor-dev
     libxfixes-dev
+    libxft-dev
+    libxrender-dev
     libxt-dev
     libxrandr-dev
 "
 BACK_ART_RUN_DEPS="
     libart-2.0-2
+    libcairo2
+    libfontconfig1
     libfreetype6
+    libgl1
     libxcursor1
     libxfixes3
+    libxft2
+    libxrender1
     libxt6
     libxrandr2
 "

--- a/Packaging/Sources/debian-12.deps.sh
+++ b/Packaging/Sources/debian-12.deps.sh
@@ -162,8 +162,7 @@ APPS_RUN_DEPS="
     xserver-xorg-input-evdev
     xserver-xorg-input-synaptics
     xfonts-100dpi
-    xserver-xorg-video-vmware
-    xserver-xorg-video-intel
+    xserver-xorg-video-all
     x11-xkb-utils
     x11-xserver-utils
 "

--- a/Packaging/Sources/debian-13.deps.sh
+++ b/Packaging/Sources/debian-13.deps.sh
@@ -1,0 +1,29 @@
+# Works for Debian 13 (trixie).
+#
+# Keep the Debian 12 dependency groups as the baseline and override only package
+# names that changed ABI/package names in Debian 13.
+
+. ./debian-12.deps.sh
+
+WRASTER_RUN_DEPS="
+    libgif7
+    libjpeg62-turbo
+    libtiff6
+    libpng16-16
+    libwebp7
+    libxpm4
+    libxmu6
+    libxext6
+    libx11-6
+"
+
+GNUSTEP_BASE_RUN_DEPS="
+    libffi8
+    libavahi-client3
+    libxml2
+    libxslt1.1
+    libicu76
+    libicu-dev
+    libgnutls30
+    libcups2
+"

--- a/Packaging/Sources/nextspace_install.sh
+++ b/Packaging/Sources/nextspace_install.sh
@@ -2,182 +2,356 @@
 # It is a helper script for automated install of NEXTSPACE which has been built
 # with scripts. Should be placed next to binary build hierarchy.
 
-. ./install_environment.sh
-. ./debian-12.deps.sh
+SCRIPT_DIR=`CDPATH= cd -- "$(dirname -- "$0")" && pwd`
+RUN_DIR=`pwd`
+
+. "${SCRIPT_DIR}/../install_environment.sh"
+ECHO="printf %b\n"
+ECHO_N="printf %b"
+. /etc/os-release
+OS_ID=${ID}
+OS_VERSION=${VERSION_ID%%.*}
+
+if command -v dnf >/dev/null 2>&1; then
+    RPM_PACKAGE_MANAGER=dnf
+elif command -v yum >/dev/null 2>&1; then
+    RPM_PACKAGE_MANAGER=yum
+fi
+
+. "${SCRIPT_DIR}/../functions.sh"
+
+if is_debian_like; then
+    DEPS_FILE="${SCRIPT_DIR}/${OS_ID}-${OS_VERSION}.deps.sh"
+    if [ ! -f "${DEPS_FILE}" ]; then
+        $ECHO "Unsupported ${OS_ID}-${OS_VERSION}: missing ${DEPS_FILE}"
+        exit 1
+    fi
+    . "${DEPS_FILE}" || exit 1
+fi
+
+find_distribution_root()
+{
+    candidate="$1"
+
+    if [ -n "$candidate" ] && [ -d "$candidate/usr/NextSpace" ]; then
+        echo "$candidate"
+        return
+    fi
+}
+
+run_source_builds()
+{
+    BUILD_SCRIPTS="
+0_build_libdispatch.sh
+1_build_libcorefoundation.sh
+2_build_libobjc2.sh
+3_build_core.sh
+3_build_tools-make.sh
+4_build_libwraster.sh
+5_build_libs-base.sh
+6_build_libs-gui.sh
+7_build_libs-back.sh
+8_build_Frameworks.sh
+9_build_Applications.sh
+"
+
+    OLD_DIR=`pwd`
+    cd "${SCRIPT_DIR}" || exit 1
+    for build_script in ${BUILD_SCRIPTS}; do
+        if [ ! -x "${build_script}" ]; then
+            chmod +x "${build_script}" 2>/dev/null
+        fi
+        if [ ! -f "${build_script}" ]; then
+            $ECHO "ERROR: Missing build script: ${SCRIPT_DIR}/${build_script}"
+            cd "${OLD_DIR}" || exit 1
+            return 1
+        fi
+        $ECHO "\033[1m"
+        $ECHO "========================================================================="
+        $ECHO "Running ${build_script}"
+        $ECHO "========================================================================="
+        $ECHO_N "\033[0m"
+        "./${build_script}"
+        if [ $? -ne 0 ]; then
+            $ECHO "\033[31mERROR: ${build_script} failed. Stopping installation.\033[0m"
+            cd "${OLD_DIR}" || exit 1
+            return 1
+        fi
+    done
+    cd "${OLD_DIR}" || exit 1
+}
+
+start_service_if_possible()
+{
+    service_name=$1
+    executable_path=$2
+
+    if [ ! -x "${executable_path}" ]; then
+        $ECHO "\033[33mWARNING: ${service_name} was not started because ${executable_path} is missing or not executable.\033[0m"
+        return 0
+    fi
+
+    if [ "${OS_ID}" = "fedora" ] || [ "${OS_ID}" = "ultramarine" ]; then
+        sudo chmod 755 "${executable_path}" 2>/dev/null
+        if command -v chcon >/dev/null 2>&1; then
+            sudo chcon -t bin_t "${executable_path}" 2>/dev/null
+        fi
+    fi
+
+    if ! systemctl --quiet is-active "${service_name}"; then
+        sudo systemctl start "${service_name}"
+        if [ $? -ne 0 ]; then
+            $ECHO "\033[31mERROR: Failed to start ${service_name}.\033[0m"
+            if [ "${OS_ID}" = "fedora" ] || [ "${OS_ID}" = "ultramarine" ]; then
+                $ECHO "\033[33mFedora hint: if status shows 203/EXEC, check SELinux AVCs with: ausearch -m avc -ts recent\033[0m"
+                $ECHO "\033[33mCurrent file context:\033[0m"
+                ls -Z "${executable_path}" 2>/dev/null
+            fi
+            systemctl --no-pager --full status "${service_name}"
+            return 1
+        fi
+        $ECHO "  ${service_name}: started"
+    else
+        $ECHO "  ${service_name}: active"
+    fi
+}
+
+configure_debian_plymouth_boot()
+{
+    if [ "${OS_ID}" != "debian" ]; then
+        return 0
+    fi
+
+    if [ ! -f /etc/default/grub ]; then
+        $ECHO "\033[33mWARNING: /etc/default/grub was not found; skipping Plymouth boot splash configuration.\033[0m"
+        return 0
+    fi
+
+    $ECHO "Configuring Debian Plymouth boot splash..."
+    tmp_grub=`mktemp` || return 1
+
+    awk '
+    BEGIN { updated = 0 }
+    /^GRUB_CMDLINE_LINUX_DEFAULT="/ {
+        args = $0
+        sub(/^GRUB_CMDLINE_LINUX_DEFAULT="/, "", args)
+        sub(/".*$/, "", args)
+        if ((" " args " ") !~ / splash /) {
+            args = args " splash"
+        }
+        print "GRUB_CMDLINE_LINUX_DEFAULT=\"" args "\""
+        updated = 1
+        next
+    }
+    { print }
+    END {
+        if (updated == 0) {
+            print "GRUB_CMDLINE_LINUX_DEFAULT=\"quiet splash\""
+        }
+    }
+    ' /etc/default/grub > "${tmp_grub}" || {
+        rm -f "${tmp_grub}"
+        return 1
+    }
+
+    if ! cmp -s "${tmp_grub}" /etc/default/grub; then
+        sudo cp "${tmp_grub}" /etc/default/grub || {
+            rm -f "${tmp_grub}"
+            return 1
+        }
+        sudo update-grub || {
+            rm -f "${tmp_grub}"
+            return 1
+        }
+        sudo update-initramfs -u || {
+            rm -f "${tmp_grub}"
+            return 1
+        }
+    else
+        $ECHO "  Plymouth boot splash already configured."
+    fi
+
+    rm -f "${tmp_grub}"
+}
+
 clear
 
-#===============================================================================
+#=========================================================================
 # Main sequence
-#===============================================================================
-$ECHO -e -n "\e[33m"
+#=========================================================================
+$ECHO_N "\033[33m"
 $ECHO "========================================================================="
 $ECHO "This script will install NEXTSPACE release $RELEASE and configure system."
 $ECHO "========================================================================="
-$ECHO -e -n "\e[1m"
-$ECHO -n "Do you want to continue? [y/N]: "
-$ECHO -e -n "\e[0m"
+$ECHO_N "\033[1m"
+$ECHO_N "Do you want to continue? [y/N]: "
+$ECHO_N "\033[0m"
 read YN
-if [ $YN != "y" ]; then
+if [ "$YN" != "y" ]; then
     $ECHO "OK, maybe next time. Exiting..."
     exit
 fi
 
-#===============================================================================
+#=========================================================================
 # Install dependency packages
-#===============================================================================
-$ECHO -e "\e[1m"
+#=========================================================================
+$ECHO "\033[1m"
 $ECHO "========================================================================="
 $ECHO "Installing system packages needed for NextSpace..."
 $ECHO "========================================================================="
-$ECHO -e -n "\e[0m"
-sudo apt-get install ${RUNTIME_RUN_DEPS} ${WRASTER_RUN_DEPS} ${GNUSTEP_BASE_RUN_DEPS} \
-                 ${GNUSTEP_GUI_RUN_DEPS} ${BACK_ART_RUN_DEPS} ${FRAMEWORKS_RUN_DEPS} \
-                 ${APPS_RUN_DEPS} 2>&1 > /dev/null
-$ECHO -e "\e[32m Done! \e[0m"
+$ECHO_N "\033[0m"
+if is_debian_like; then
+    install_apt_packages ${RUNTIME_RUN_DEPS} ${WRASTER_RUN_DEPS} ${GNUSTEP_BASE_RUN_DEPS} \
+                         ${GNUSTEP_GUI_RUN_DEPS} ${BACK_ART_RUN_DEPS} ${FRAMEWORKS_RUN_DEPS} \
+                         ${APPS_RUN_DEPS}
+elif [ "${OS_ID}" = "fedora" ] || [ "${OS_ID}" = "ultramarine" ]; then
+    if [ -z "${RPM_PACKAGE_MANAGER}" ]; then
+        $ECHO "Neither dnf nor yum was found. Cannot install Fedora dependencies."
+        exit 1
+    fi
+    install_rpm_packages xorg-x11-drivers xorg-x11-xinit
+else
+    $ECHO "Unsupported OS for automatic package installation: ${OS_ID}-${OS_VERSION}"
+    exit 1
+fi
+$ECHO "\033[32m Done! \033[0m"
 
-#===============================================================================
+#=========================================================================
 # Extract distribution
-#===============================================================================
-$ECHO -e "\e[1m"
+#=========================================================================
+$ECHO "\033[1m"
 $ECHO "========================================================================="
 $ECHO "Installing NextSpace..."
 $ECHO "========================================================================="
-$ECHO -e -n "\e[0m"
-$ECHO "Populating /etc..."
-CORE_SOURCES="."
+$ECHO_N "\033[0m"
+CORE_SOURCES=`find_distribution_root "$1"`
 DEST_DIR=""
-{
-    # Preferences
-    $MKDIR_CMD $DEST_DIR/Library/Preferences
-    $CP_CMD ${CORE_SOURCES}/Library/Preferences/* $DEST_DIR/Library/Preferences/
 
-    # Linker cache
-    if ! [ -d $DEST_DIR/etc/ld.so.conf.d ];then
-        $MKDIR_CMD -v $DEST_DIR/etc/ld.so.conf.d
+run_source_builds || exit 1
+
+if [ -n "$CORE_SOURCES" ]; then
+    $ECHO "Using distribution root: $CORE_SOURCES"
+
+    if [ -d "$CORE_SOURCES/Applications" ]; then
+        $ECHO "Copying /Applications..."
+        $CP_CMD "$CORE_SOURCES"/Applications /
     fi
-    $CP_CMD ${CORE_SOURCES}/etc/ld.so.conf.d/nextspace.conf $DEST_DIR/etc/ld.so.conf.d/
-    sudo ldconfig
-
-    # X11
-    if ! [ -d $DEST_DIR/etc/X11/xorg.conf.d ];then
-        $MKDIR_CMD -v $DEST_DIR/etc/X11/xorg.conf.d
+    if [ -d "$CORE_SOURCES/Developer" ]; then
+        $ECHO "Copying /Developer..."
+        $CP_CMD "$CORE_SOURCES"/Developer /
     fi
-    $CP_CMD ${CORE_SOURCES}/etc/X11/Xresources.nextspace $DEST_DIR/etc/X11
-    $CP_CMD ${CORE_SOURCES}/etc/X11/xorg.conf.d/*.conf $DEST_DIR/etc/X11/xorg.conf.d/
-
-    # PolKit & udev
-    if ! [ -d $DEST_DIR/etc/polkit-1/rules.d ];then
-        $MKDIR_CMD -v $DEST_DIR/etc/polkit-1/rules.d
+    if [ -d "$CORE_SOURCES/Library" ]; then
+        $ECHO "Copying /Library..."
+        $CP_CMD "$CORE_SOURCES"/Library /
     fi
-    $CP_CMD ${CORE_SOURCES}/etc/polkit-1/rules.d/*.rules $DEST_DIR/etc/polkit-1/rules.d/
-    if ! [ -d $DEST_DIR/etc/udev/rules.d ];then
-        $MKDIR_CMD -v $DEST_DIR/etc/udev/rules.d
+    if [ -d "$CORE_SOURCES/usr/NextSpace" ]; then
+        $ECHO "Copying /usr/NextSpace..."
+        $CP_CMD "$CORE_SOURCES"/usr/NextSpace /usr
     fi
-    $CP_CMD ${CORE_SOURCES}/etc/udev/rules.d/*.rules $DEST_DIR/etc/udev/rules.d/
-
-    # User environment
-    if ! [ -d $DEST_DIR/etc/profile.d ];then
-        $MKDIR_CMD -v $DEST_DIR/etc/profile.d
+else
+    if [ -d /usr/NextSpace ]; then
+        $ECHO "No binary distribution tree found; using existing /usr/NextSpace installation."
+        if [ ! -f /etc/ld.so.conf.d/nextspace.conf ]; then
+            $MKDIR_CMD -v /etc/ld.so.conf.d
+            echo "/usr/NextSpace/lib" | sudo tee /etc/ld.so.conf.d/nextspace.conf >/dev/null
+        fi
+    else
+        $ECHO "ERROR: /usr/NextSpace was not created by the source build."
+        $ECHO "If you need to install from a binary distribution tree, pass that path as the first argument."
+        exit 1
     fi
-    $CP_CMD ${CORE_SOURCES}/etc/profile.d/nextspace.sh $DEST_DIR/etc/profile.d/
+fi
+refresh_ldconfig
 
-    if ! [ -d $DEST_DIR/etc/skel ];then
-        $MKDIR_CMD -v $DEST_DIR/etc/skel
-    fi
-    $CP_CMD ${CORE_SOURCES}/etc/skel/Library $DEST_DIR/etc/skel/
-    $CP_CMD ${CORE_SOURCES}/etc/skel/.config $DEST_DIR/etc/skel/
-    $CP_CMD ${CORE_SOURCES}/etc/skel/.emacs.d $DEST_DIR/etc/skel/
-    $CP_CMD ${CORE_SOURCES}/etc/skel/.gtkrc-2.0 $DEST_DIR/etc/skel/
-    $CP_CMD ${CORE_SOURCES}/etc/skel/.*.nextspace $DEST_DIR/etc/skel/
-
-    # Scripts
-    if ! [ -d $DEST_DIR/usr/NextSpace/bin ];then
-        $MKDIR_CMD -v $DEST_DIR/usr/NextSpace/bin
-    fi
-    $CP_CMD ${CORE_SOURCES}/usr/NextSpace/bin/* $DEST_DIR/usr/NextSpace/bin/
-
-    # Icons and Plymouth resources
-    if ! [ -d $DEST_DIR/usr/share ];then
-        $MKDIR_CMD -v $DEST_DIR/usr/share
-    fi
-    $CP_CMD ${CORE_SOURCES}/usr/share/* $DEST_DIR/usr/share/
-
-    $ECHO "Copying /Applications..."
-    $CP_CMD Applications /
-    $ECHO "Copying /Developer..."
-    $CP_CMD Developer /
-    $ECHO "Copying /Library..."
-    $CP_CMD Library /
-    $ECHO "Copying /usr/NextSpace..."
-    $CP_CMD usr/NextSpace /usr
-}
-sudo ldconfig
-
-#===============================================================================
+#=========================================================================
 # More X drivers. Workaround until NextSpace RPMs include them as dependencies
-#===============================================================================
-$ECHO -e "\e[1m"
+#=========================================================================
+$ECHO "\033[1m"
 $ECHO "========================================================================="
 $ECHO "Installing X11 drivers and utilities..."
 $ECHO "========================================================================="
-$ECHO -e -n "\e[0m"
-sudo apt-get install xserver-xorg-input-all xserver-xorg-video-all 2>&1 > /dev/null
-$ECHO -e "\e[32m Done! \e[0m"
+$ECHO_N "\033[0m"
+if is_debian_like; then
+    install_apt_packages xserver-xorg-input-all xserver-xorg-video-all
+elif [ "${OS_ID}" = "fedora" ] || [ "${OS_ID}" = "ultramarine" ]; then
+    install_rpm_packages xorg-x11-drivers xorg-x11-xinit
+fi
+$ECHO "\033[32m Done! \033[0m"
 
-$ECHO -e "\e[1m"
+$ECHO "\033[1m"
 $ECHO "========================================================================="
 $ECHO "Performing system check and configuration..."
 $ECHO "========================================================================="
-$ECHO -e -n "\e[0m"
-#===============================================================================
+$ECHO_N "\033[0m"
+#=========================================================================
 # Hostname in /etc/hosts
-#===============================================================================
+#=========================================================================
 setup_hosts
 
-#===============================================================================
-# Enable services
-#===============================================================================
-sudo systemctl daemon-reload
-$ECHO -n "Checking for Distributed Objects Mapper: "
-systemctl is-enabled gdomap
-if [ $? -ne 0 ];then
-    $ECHO "Enabling Distributed Objects Mapper service..."
-    sudo systemctl enable /usr/NextSpace/lib/systemd/gdomap.service
-    sudo systemctl start gdomap
+if [ "${OS_ID}" = "fedora" ] || [ "${OS_ID}" = "ultramarine" ]; then
+    $ECHO "Preparing Fedora service executable contexts..."
+    for ns_exec in /Library/bin/gdomap /Library/bin/gdnc /Library/bin/gpbs; do
+        if [ -f "$ns_exec" ]; then
+            sudo chmod 755 "$ns_exec" 2>/dev/null
+            if command -v chcon >/dev/null 2>&1; then
+                sudo chcon -t bin_t "$ns_exec" 2>/dev/null
+            fi
+        fi
+    done
 fi
-$ECHO -n "Checking for Distributed Notification Center: "
-systemctl is-enabled gdnc
+
+#=========================================================================
+# Enable services
+#=========================================================================
+sudo systemctl daemon-reload
+$ECHO "Checking for Distributed Objects Mapper..."
+systemctl --quiet is-enabled gdomap
 if [ $? -ne 0 ];then
-    $ECHO "Enabling Distributed Notification Center service..."
+    $ECHO "  gdomap: enabling"
+    sudo systemctl enable /usr/NextSpace/lib/systemd/gdomap.service
+else
+    $ECHO "  gdomap: enabled"
+fi
+start_service_if_possible gdomap /Library/bin/gdomap || exit 1
+$ECHO "Checking for Distributed Notification Center..."
+systemctl --quiet is-enabled gdnc
+if [ $? -ne 0 ];then
+    $ECHO "  gdnc: enabling"
     sudo systemctl enable /usr/NextSpace/lib/systemd/gdnc.service
     sudo systemctl enable /usr/NextSpace/lib/systemd/gdnc-local.service
-    sudo systemctl start gdnc gdnc-local
+else
+    $ECHO "  gdnc: enabled"
 fi
-$ECHO -n "Checking for Pasteboard: "
-systemctl is-enabled gpbs
+start_service_if_possible gdnc /Library/bin/gdnc || exit 1
+start_service_if_possible gdnc-local /Library/bin/gdnc || exit 1
+$ECHO "Checking for Pasteboard..."
+systemctl --quiet is-enabled gpbs
 if [ $? -ne 0 ];then
-    $ECHO "Enabling Pasteboard service..."
+    $ECHO "  gpbs: enabling"
     sudo systemctl enable /usr/NextSpace/lib/systemd/gpbs.service
-    sudo systemctl start gpbs
+else
+    $ECHO "  gpbs: enabled"
 fi
-$ECHO -n "Checking for Login panel: "
-systemctl is-enabled loginwindow
+start_service_if_possible gpbs /Library/bin/gpbs || exit 1
+$ECHO "Checking for Login panel..."
+systemctl --quiet is-enabled loginwindow
 if [ $? -ne 0 ];then
-    $ECHO "Enabling Login panel service..."
+    $ECHO "  loginwindow: enabling"
     sudo systemctl enable /usr/NextSpace/lib/systemd/loginwindow.service
+else
+    $ECHO "  loginwindow: enabled"
 fi
-$ECHO
 
-#===============================================================================
+#=========================================================================
 # SELinux configuration
-#===============================================================================
+#=========================================================================
 #setup_selinux
 
-$ECHO -e -n "\e[1m"
+$ECHO_N "\033[1m"
 $ECHO "========================================================================="
 $ECHO "Post-install optional configuration"
 $ECHO "========================================================================="
-$ECHO -e -n "\e[0m"
+$ECHO_N "\033[0m"
 
 # Adding user
 add_user
@@ -185,9 +359,12 @@ add_user
 # Setting up Login Panel
 setup_loginwindow
 
+# Setting up Plymouth boot splash on Debian
+configure_debian_plymouth_boot || exit 1
 
-$ECHO -e "\e[32m"
+
+$ECHO "\033[32m"
 $ECHO "========================================================================="
 $ECHO "    NEXTSPACE $RELEASE successfuly installed! Wolcome to the NeXT world! "
 $ECHO "========================================================================="
-$ECHO -e "\e[0m"
+$ECHO "\033[0m"

--- a/Packaging/Sources/ubuntu-24.deps.sh
+++ b/Packaging/Sources/ubuntu-24.deps.sh
@@ -1,0 +1,44 @@
+# Works for Ubuntu 24.04 LTS (noble).
+#
+# Keep the Debian 12 / Ubuntu 22.04 dependency groups as the baseline and
+# override package names that changed ABI/package names in Ubuntu 24.04.
+
+. ./debian-12.deps.sh
+
+WRASTER_RUN_DEPS="
+    libgif7
+    libjpeg8
+    libtiff6
+    libpng16-16
+    libwebp7
+    libxpm4
+    libxmu6
+    libxext6
+    libx11-6
+"
+
+GNUSTEP_BASE_RUN_DEPS="
+    libffi8
+    libavahi-client3
+    libxml2
+    libxslt1.1
+    libicu74
+    libicu-dev
+    libgnutls30t64
+    libcups2t64
+"
+
+FRAMEWORKS_RUN_DEPS="
+    libmagic1
+    libglib2.0-0t64
+    dbus
+    libdbus-1-3
+    udisks2
+    libudisks2-0
+    libupower-glib3
+    libxkbfile1
+    libxrandr2
+    pulseaudio
+    libpulse0
+    upower
+"

--- a/Packaging/environment.sh
+++ b/Packaging/environment.sh
@@ -1,14 +1,15 @@
 ###############################################################################
 # Variables
 ###############################################################################
-ECHO="/usr/bin/echo -e"
+ECHO="printf %b\n"
+ECHO_N="printf %b"
 _PWD=`pwd`
 
 #----------------------------------------
 # Libraries and applications
 #----------------------------------------
 # Apple
-libdispatch_version=5.9.2
+libdispatch_version=6.0.2
 libcorefoundation_version=5.9.2
 libcfnetwork_version=129.20
 # GNUstep
@@ -24,16 +25,16 @@ projectcenter_version=0_7_0
 #----------------------------------------
 . /etc/os-release
 # OS type like "rhel"
-OS_LIKE=`echo ${ID_LIKE} | awk '{print $1}'`
+OS_LIKE=`echo "${ID_LIKE}" | awk '{print $1}'`
 # OS name like "fedora"
-OS_ID=$ID
-_ID=`echo ${ID} | awk -F\" '{print $2}'`
+OS_ID="$ID"
+_ID=`echo "${ID}" | awk -F\" '{print $2}'`
 if [ -n "${_ID}" ] && [ "${_ID}" != " " ]; then
   OS_ID=${_ID}
 fi
 # OS version like "39"
-OS_VERSION=$VERSION_ID
-_VER=`echo ${VERSION_ID} | awk -F\. '{print $1}'`
+OS_VERSION="$VERSION_ID"
+_VER=`echo "${VERSION_ID}" | awk -F\. '{print $1}'`
 if [ -n "${_VER}" ] && [ "${_VER}" != " " ]; then
   OS_VERSION=$_VER
 fi
@@ -66,7 +67,7 @@ PROJECT_DIR=`pwd`
 ${ECHO} "NextSpace repo:\t${PROJECT_DIR}"
 cd ${_PWD}
 
-if [ -z $BUILD_RPM ]; then
+if [ -z "$BUILD_RPM" ]; then
   BUILD_ROOT="${_PWD}/BUILD_ROOT"
   if [ ! -d ${BUILD_ROOT} ]; then
     mkdir ${BUILD_ROOT}
@@ -99,8 +100,13 @@ fi
 #----------------------------------------
 # Package dependencies
 #----------------------------------------
-if [ ${OS_ID} = "debian" ] || [ ${OS_ID} = "ubuntu" ]; then
-    . ./${OS_ID}-${OS_VERSION}.deps.sh || exit 1
+if [ "${OS_ID}" = "debian" ] || [ "${OS_ID}" = "ubuntu" ]; then
+    DEPS_FILE="./${OS_ID}-${OS_VERSION}.deps.sh"
+    if [ ! -f "${DEPS_FILE}" ]; then
+      echo "Unsupported ${OS_ID}-${OS_VERSION}: missing ${DEPS_FILE}"
+      exit 1
+    fi
+    . "${DEPS_FILE}" || exit 1
 else
     prepare_redhat_environment
 fi
@@ -122,6 +128,20 @@ else
   INSTALL_CMD="sudo -E ${MAKE_CMD} install"
 fi
 
+run_install()
+{
+  _install_log="${BUILD_ROOT}/install-$RANDOM.log"
+  if [ "$DEST_DIR" != "" ];then
+    ${MAKE_CMD} install DESTDIR=${DEST_DIR} "$@" > "${_install_log}" 2>&1
+  else
+    sudo -E ${MAKE_CMD} install "$@" > "${_install_log}" 2>&1
+  fi
+  _install_status=$?
+  sed "/Nothing to be done for 'install'\./d" "${_install_log}"
+  rm -f "${_install_log}"
+  return ${_install_status}
+}
+
 # Utilities
 if [ "$1" != "" ];then
   RM_CMD="rm"
@@ -138,24 +158,37 @@ else
 fi
 
 # Linker
-ld -v | grep "gold" 2>&1 > /dev/null
-if [ "$?" = "1" ]; then
-  ${ECHO} "Setting up Gold linker..."
-  sudo update-alternatives --install /usr/bin/ld ld /usr/bin/ld.gold 100
-  sudo update-alternatives --install /usr/bin/ld ld /usr/bin/ld.bfd 10
-  sudo update-alternatives --auto ld
-  ld -v | grep "gold" 2>&1 > /dev/null
-  if [ "$?" = "1" ]; then
-    ${ECHO} "Failed to setup Gold linker"
-    exit 1
+LD_GOLD_FLAG=""
+if [ -x /usr/bin/ld.gold ]; then
+  LD_GOLD_FLAG="-fuse-ld=/usr/bin/ld.gold"
+fi
+
+if command -v ld >/dev/null 2>&1; then
+  if ld -v 2>/dev/null | grep "gold" >/dev/null 2>&1; then
+    ${ECHO} "Using linker:\tGold"
+  else
+    ${ECHO} "Using linker:\t`ld -v 2>&1 | head -n 1`"
   fi
 else
-  ${ECHO} "Using linker:\tGold"
+  ${ECHO} "Linker not found yet; build scripts will install binutils via BUILD_TOOLS."
 fi
+
 # Compiler
 if [ "$OS_ID" = "fedora" ] || [ "$OS_LIKE" = "rhel" ] || [ "$OS_ID" = "debian" ] || [ "$OS_ID" = "ubuntu" ] || [ "$OS_ID" = "ultramarine" ]; then
-  which clang 2>&1 > /dev/null || { echo "No clang compiler found. Please install clang package."; exit 1; }
-  C_COMPILER=`which clang`
-  which clang++ 2>&1 > /dev/null || { echo "No clang++ compiler found. Please install clang++ package."; exit 1; }
-  CXX_COMPILER=`which clang++`
+  if [ -n "${CC:-}" ]; then
+    C_COMPILER="${CC}"
+  elif command -v clang >/dev/null 2>&1; then
+    C_COMPILER=`command -v clang`
+  else
+    ${ECHO} "clang not found yet; build scripts will install it via BUILD_TOOLS."
+    C_COMPILER=clang
+  fi
+  if [ -n "${CXX:-}" ]; then
+    CXX_COMPILER="${CXX}"
+  elif command -v clang++ >/dev/null 2>&1; then
+    CXX_COMPILER=`command -v clang++`
+  else
+    ${ECHO} "clang++ not found yet; build scripts will install it via BUILD_TOOLS."
+    CXX_COMPILER=clang++
+  fi
 fi

--- a/Packaging/functions.sh
+++ b/Packaging/functions.sh
@@ -131,7 +131,7 @@ refresh_ldconfig()
 
 reload_systemd_if_live()
 {
-    if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true" ]; then
+    if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true" ] && [ "$CI" != "true" ]; then
         sudo systemctl daemon-reload || exit 1
     fi
 }
@@ -141,8 +141,96 @@ enable_service_once()
     service_name=$1
     unit_path=$2
 
-    if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true" ]; then
+    if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true" ] && [ "$CI" != "true" ]; then
         systemctl --quiet is-enabled "${service_name}" || sudo systemctl enable "${unit_path}" || exit 1
+    fi
+}
+
+configure_debian_plymouth_boot()
+{
+    if [ "${OS_ID}" != "debian" ]; then
+        return 0
+    fi
+
+    if [ ! -f /etc/default/grub ]; then
+        $ECHO "\033[33mWARNING: /etc/default/grub was not found; skipping Plymouth boot splash configuration.\033[0m"
+        return 0
+    fi
+
+    $ECHO "Configuring Debian Plymouth boot splash..."
+    tmp_grub=`mktemp` || return 1
+
+    awk '
+    BEGIN { updated = 0 }
+    /^GRUB_CMDLINE_LINUX_DEFAULT="/ {
+        args = $0
+        sub(/^GRUB_CMDLINE_LINUX_DEFAULT="/, "", args)
+        sub(/".*$/, "", args)
+        if ((" " args " ") !~ / splash /) {
+            args = args " splash"
+        }
+        print "GRUB_CMDLINE_LINUX_DEFAULT=\"" args "\""
+        updated = 1
+        next
+    }
+    { print }
+    END {
+        if (updated == 0) {
+            print "GRUB_CMDLINE_LINUX_DEFAULT=\"quiet splash\""
+        }
+    }
+    ' /etc/default/grub > "${tmp_grub}" || {
+        rm -f "${tmp_grub}"
+        return 1
+    }
+
+    if ! cmp -s "${tmp_grub}" /etc/default/grub; then
+        sudo cp "${tmp_grub}" /etc/default/grub || {
+            rm -f "${tmp_grub}"
+            return 1
+        }
+        sudo update-grub || {
+            rm -f "${tmp_grub}"
+            return 1
+        }
+        sudo update-initramfs -u || {
+            rm -f "${tmp_grub}"
+            return 1
+        }
+    else
+        $ECHO "  Plymouth boot splash already configured."
+    fi
+
+    rm -f "${tmp_grub}"
+}
+
+configure_plymouth_theme()
+{
+    theme_name=$1
+
+    if [ -z "${theme_name}" ]; then
+        return 0
+    fi
+
+    if [ "$DEST_DIR" != "" ] || [ "$GITHUB_ACTIONS" = "true" ] || [ "$CI" = "true" ]; then
+        $ECHO "Skipping Plymouth theme activation in build/CI environment."
+        return 0
+    fi
+
+    if [ -f /.dockerenv ] || { command -v systemd-detect-virt >/dev/null 2>&1 && systemd-detect-virt --container --quiet; }; then
+        $ECHO "Skipping Plymouth theme activation inside container."
+        return 0
+    fi
+
+    if [ ! -d "/lib/modules/`uname -r`" ]; then
+        $ECHO "\033[33mWARNING: /lib/modules/`uname -r` was not found; skipping Plymouth initramfs regeneration.\033[0m"
+        return 0
+    fi
+
+    if command -v plymouth-set-default-theme >/dev/null 2>&1; then
+        if [ ! "`plymouth-set-default-theme`" = "${theme_name}" ]; then
+            plymouth-set-default-theme -R "${theme_name}" || return 1
+        fi
     fi
 }
 

--- a/Packaging/functions.sh
+++ b/Packaging/functions.sh
@@ -2,6 +2,17 @@
 # Functions
 ###############################################################################
 
+: ${ECHO:="printf %b\n"}
+: ${ECHO_N:="printf %b"}
+
+if command -v dnf >/dev/null 2>&1; then
+    RPM_PACKAGE_MANAGER=dnf
+elif command -v yum >/dev/null 2>&1; then
+    RPM_PACKAGE_MANAGER=yum
+else
+    RPM_PACKAGE_MANAGER=dnf
+fi
+
 git_remote_archive() {
   local url="$1"
   local dest="$2"
@@ -21,11 +32,118 @@ git_remote_archive() {
 }
 
 install_packages() {
-  apt-get install -y $@ || exit 1
+  apt-get install ${APT_INSTALL_OPTIONS:--y} $@ || exit 1
 }
 
 uninstall_packages() {
   apt-get purge -y $@ || exit 1
+}
+
+is_debian_like()
+{
+    [ "${OS_ID}" = "debian" ] || [ "${OS_ID}" = "ubuntu" ]
+}
+
+is_rpm_like()
+{
+    ! is_debian_like
+}
+
+install_apt_packages()
+{
+    if [ $# -eq 0 ]; then
+        return 0
+    fi
+    sudo apt-get install ${APT_INSTALL_OPTIONS:--y} "$@" || exit 1
+}
+
+install_rpm_packages()
+{
+    if [ $# -eq 0 ]; then
+        return 0
+    fi
+    sudo ${RPM_PACKAGE_MANAGER} -y install "$@" || exit 1
+}
+
+rpm_spec_deps()
+{
+    query_flag=$1
+    spec_file=$2
+    shift 2
+
+    rpmspec -q "${query_flag}" "${spec_file}" | awk '{print $1}' | while read dep_name; do
+        skip_dep=0
+        for skip_pattern in "$@"; do
+            echo "${dep_name}" | grep -q "${skip_pattern}" && skip_dep=1
+        done
+        [ ${skip_dep} -eq 0 ] && echo "${dep_name}"
+    done
+}
+
+install_rpm_spec_buildrequires()
+{
+    spec_file=$1
+    shift
+    deps=`rpm_spec_deps --buildrequires "${spec_file}" "$@"`
+    install_rpm_packages ${deps}
+}
+
+install_rpm_spec_requires()
+{
+    spec_file=$1
+    shift
+    deps=`rpm_spec_deps --requires "${spec_file}" "$@"`
+    install_rpm_packages ${deps}
+}
+
+download_tarball_once()
+{
+    url=$1
+    archive_file=$2
+    extract_dir=$3
+
+    if [ ! -d "${extract_dir}" ]; then
+        curl -L "${url}" -o "${archive_file}" || exit 1
+        old_dir=`pwd`
+        cd "${BUILD_ROOT}" || exit 1
+        tar zxf "${archive_file}" || exit 1
+        cd "${old_dir}" || exit 1
+    fi
+}
+
+copy_clean_build_tree()
+{
+    source_dir=$1
+    build_dir=$2
+
+    if [ -d "${build_dir}" ]; then
+        rm -rf "${build_dir}" || exit 1
+    fi
+    cp -R "${source_dir}" "${BUILD_ROOT}" || exit 1
+}
+
+refresh_ldconfig()
+{
+    if [ "$DEST_DIR" = "" ]; then
+        sudo ldconfig
+    fi
+}
+
+reload_systemd_if_live()
+{
+    if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true" ]; then
+        sudo systemctl daemon-reload || exit 1
+    fi
+}
+
+enable_service_once()
+{
+    service_name=$1
+    unit_path=$2
+
+    if [ "$DEST_DIR" = "" ] && [ "$GITHUB_ACTIONS" != "true" ]; then
+        systemctl --quiet is-enabled "${service_name}" || sudo systemctl enable "${unit_path}" || exit 1
+    fi
 }
 
 rpm_version()
@@ -52,8 +170,8 @@ build_rpm()
 {
     SPEC_FILE=$1
     spectool -g -R ${SPEC_FILE}
-    DEPS=`rpmspec -q --buildrequires ${SPEC_FILE} | awk -c '{print $1}'`
-    sudo yum -y install ${DEPS}
+    DEPS=`rpmspec -q --buildrequires ${SPEC_FILE} | awk '{print $1}'`
+    sudo ${RPM_PACKAGE_MANAGER} -y install ${DEPS}
     run_rpmbuild ${SPEC_FILE}
 }
 
@@ -88,75 +206,76 @@ install_rpm()
     else
         INST_CMD=reinstall
     fi
-    sudo yum -y $INST_CMD $2 || exit 1
+    sudo ${RPM_PACKAGE_MANAGER} -y $INST_CMD $2 || exit 1
 }
 
 # Bold
 print_H1()
 {
-    echo -e -n "\e[1m"
-    echo "================================================================================"
-    echo -e -n "\e[1m"
-    echo -e "$1"
-    echo -e -n "\e[1m"
-    echo "================================================================================"
-    echo -e -n "\e[0m"
+    $ECHO_N "\033[1m"
+        $ECHO "========================================================================="
+    $ECHO_N "\033[1m"
+    $ECHO "$1"
+    $ECHO_N "\033[1m"
+        $ECHO "========================================================================="
+    $ECHO_N "\033[0m"
 }
 
 # Brown
 print_H2()
 {
-    echo -e -n "\e[33m"
-    echo -e "$1"
-    echo -e -n "\e[0m"
+    $ECHO_N "\033[33m"
+    $ECHO "$1"
+    $ECHO_N "\033[0m"
 }
 
 # Green
 print_OK()
 {
-    echo -e -n "\e[32m"
-    echo "================================================================================"
-    echo -e -n "\e[32m"
-    echo -e "$1"
-    echo -e -n "\e[32m"
-    echo "================================================================================"
-    echo -e -n "\e[0m"
+    $ECHO_N "\033[32m"
+        $ECHO "========================================================================="
+    $ECHO_N "\033[32m"
+    $ECHO "$1"
+    $ECHO_N "\033[32m"
+        $ECHO "========================================================================="
+    $ECHO_N "\033[0m"
 }
 
 # Red
 print_ERR()
 {
-    echo -e -n "\e[31m"
-    echo "================================================================================"
-    echo -e -n "\e[31m"
-    echo -e "$1"
-    echo -e -n "\e[31m"
-    echo "================================================================================"
-    echo -e -n "\e[0m"
+    $ECHO_N "\033[31m"
+        $ECHO "========================================================================="
+    $ECHO_N "\033[31m"
+    $ECHO "$1"
+    $ECHO_N "\033[31m"
+        $ECHO "========================================================================="
+    $ECHO_N "\033[0m"
 }
 
 prepare_redhat_environment() 
 {
     print_H1 " Prepare build environment"
     print_H2 "===== Install RPM build tools..."
+    BUILD_TOOLS=""
     
     rpm -q rpm-build 2>&1 > /dev/null
-    if [ $? -eq 1 ]; then BUILD_TOOLS+=" rpm-build"; fi
+    if [ $? -eq 1 ]; then BUILD_TOOLS="${BUILD_TOOLS} rpm-build"; fi
     rpm -q rpmdevtools 2>&1 > /dev/null
-    if [ $? -eq 1 ]; then BUILD_TOOLS+=" rpmdevtools"; fi
+    if [ $? -eq 1 ]; then BUILD_TOOLS="${BUILD_TOOLS} rpmdevtools"; fi
     rpm -q make 2>&1 > /dev/null
-    if [ $? -eq 1 ]; then BUILD_TOOLS+=" make"; fi
+    if [ $? -eq 1 ]; then BUILD_TOOLS="${BUILD_TOOLS} make"; fi
     rpm -q patch 2>&1 > /dev/null
-    if [ $? -eq 1 ]; then BUILD_TOOLS+=" patch"; fi
+    if [ $? -eq 1 ]; then BUILD_TOOLS="${BUILD_TOOLS} patch"; fi
 
     if [ -f /etc/os-release ]; then 
 	    if [ "${OS_ID}" = "rhel" ] && [ "${OS_VERSION}" = "9" ];then
-            sudo dnf -y install epel-release
-            sudo dnf config-manager --set-enabled crb
-            sudo dnf -y install clang
+            sudo ${RPM_PACKAGE_MANAGER} -y install epel-release
+            sudo ${RPM_PACKAGE_MANAGER} config-manager --set-enabled crb
+            sudo ${RPM_PACKAGE_MANAGER} -y install clang
         else
             if [ "$OS_ID" = "fedora" ] || [ "$OS_ID" = "ultramarine" ];then
-                sudo dnf -y install clang binutils-gold
+                sudo ${RPM_PACKAGE_MANAGER} -y install clang binutils-gold
             else
                 print_H2 ">>>>> Can't find /etc/os-release - this OS is unsupported."
                 return 1
@@ -165,7 +284,7 @@ prepare_redhat_environment()
     fi
     
     if [ "${BUILD_TOOLS}" != "" ]; then
-        sudo dnf -y install ${BUILD_TOOLS}
+        sudo ${RPM_PACKAGE_MANAGER} -y install ${BUILD_TOOLS}
     fi
 }
 

--- a/Packaging/install_environment.sh
+++ b/Packaging/install_environment.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-ECHO="/bin/echo -e"
+ECHO="printf %b\n"
+ECHO_N="printf %b"
 MKDIR_CMD="sudo mkdir -p"
 RM_CMD="sudo rm"
 LN_CMD="sudo ln -sf"
@@ -9,24 +10,29 @@ CP_CMD="sudo cp -R"
 
 RELEASE=0.95
 
-#===============================================================================
+#=========================================================================
 # SELinux setup
-#===============================================================================
+#=========================================================================
 setup_selinux()
 {
-    $ECHO -e -n "\e[1m"
-    $ECHO "==============================================================================="
+    if ! command -v getenforce >/dev/null 2>&1; then
+        $ECHO "SELinux tools were not found; skipping SELinux configuration."
+        return
+    fi
+
+    $ECHO_N "\033[1m"
+    $ECHO "========================================================================="
     $ECHO "SELinux configuration"
-    $ECHO "==============================================================================="
-    $ECHO -e -n "\e[0m"
+    $ECHO "========================================================================="
+    $ECHO_N "\033[0m"
     SELINUX_MODE=$(getenforce)
 
-    $ECHO -e -n "\e[1m"
+    $ECHO_N "\033[1m"
     $ECHO "Current SELinux mode is ${SELINUX_MODE}"
-    $ECHO -e -n "\e[0m"
-    $ECHO -e -n "\e[33m"
-    $ECHO -n "Do you want to change your SELinux configuration? [y/N]: "
-    $ECHO -e -n "\e[0m"
+    $ECHO_N "\033[0m"
+    $ECHO_N "\033[33m"
+        $ECHO_N "Do you want to change your SELinux configuration? [y/N]: "
+    $ECHO_N "\033[0m"
     read YN
 
     if [ "$YN" = "y" ]; then
@@ -50,11 +56,11 @@ setup_selinux()
         $ECHO "Filesystem with undergo automatic relabelling upon reboot for \"Permissive\" "
         $ECHO "and \"Enforcing\" policies".
         $ECHO
-        $ECHO -e -n "\e[1m"
-        $ECHO -n "SELinux mode [default: 1]: "
-        $ECHO -e -n "\e[0m"
+        $ECHO_N "\033[1m"
+        $ECHO_N "SELinux mode [default: 1]: "
+        $ECHO_N "\033[0m"
         read SEL
-        $ECHO -n "Setting SELinux default mode to "
+        $ECHO_N "Setting SELinux default mode to "
         if [ "$SEL" = 2 ]; then
             $ECHO Enforcing...
             sudo sed -i -e ' s/SELINUX=.*/SELINUX=enforcing/' /etc/selinux/config
@@ -74,42 +80,54 @@ setup_selinux()
 
 setup_hosts()
 {
-    $ECHO -n "Checking /etc/hosts..."
+        $ECHO_N "Checking /etc/hosts..."
     HOSTNAME="`hostname -s`"
     grep "$HOSTNAME" /etc/hosts 2>&1 > /dev/null
     if [ $? -eq 1 ];then
-        if [ $HOSTNAME != `hostname` ];then
+        if [ "$HOSTNAME" != "`hostname`" ];then
             HOSTNAME="$HOSTNAME `hostname`"
         fi
-        $ECHO -e -n "\e[33m"
+        $ECHO_N "\033[33m"
         $ECHO "configuring needed"
-        $ECHO -e -n "\e[0m"
+        $ECHO_N "\033[0m"
         $ECHO "Configuring hostname ($HOSTNAME)..."
-        sed -i 's/localhost4.localdomain4/localhost4.localdomain4 '"$HOSTNAME"'/g' /etc/hosts
+        if grep "localhost4.localdomain4" /etc/hosts >/dev/null 2>&1; then
+            sudo sed -i 's/localhost4.localdomain4/localhost4.localdomain4 '"$HOSTNAME"'/g' /etc/hosts
+        else
+            echo "127.0.1.1 $HOSTNAME" | sudo tee -a /etc/hosts >/dev/null
+        fi
     else
-        $ECHO -e -n "\e[32m"
+        $ECHO_N "\033[32m"
         $ECHO "good"
-        $ECHO -e -n "\e[0m"
+        $ECHO_N "\033[0m"
     fi
 }
 
 add_user()
 {
-    $ECHO -e -n "\e[33m"
-    $ECHO -n "Do you want to add user? [y/N]: "
-    $ECHO -e -n "\e[0m"
+    $ECHO_N "\033[33m"
+        $ECHO_N "Do you want to add user? [y/N]: "
+    $ECHO_N "\033[0m"
     read YN
     if [ "$YN" = "y" ]; then
-        $ECHO -n "Please enter username: "
+        $ECHO_N "Please enter username: "
         read USERNAME
         $ECHO "Adding username $USERNAME"
-        sudo adduser -b /Users -s /bin/zsh -G audio,wheel $USERNAME
+        EXTRA_GROUPS="audio"
+        if getent group wheel >/dev/null 2>&1; then
+            EXTRA_GROUPS="${EXTRA_GROUPS},wheel"
+        elif getent group sudo >/dev/null 2>&1; then
+            EXTRA_GROUPS="${EXTRA_GROUPS},sudo"
+        fi
+        sudo useradd -m -b /Users -s /bin/zsh -G "$EXTRA_GROUPS" "$USERNAME"
         $ECHO "Setting up password..."
-        sudo passwd $USERNAME
-        $ECHO "Updating SELinux file contexts..."
-        ## Needed to update the filesystem contexts that depend on HOME_DIR, and wrongly assume /home
-        sudo semodule -e ns-core  2>&1 > /dev/null
-        sudo restorecon -R /Users 2>&1 > /dev/null
+        sudo passwd "$USERNAME"
+        if command -v semodule >/dev/null 2>&1 && command -v restorecon >/dev/null 2>&1; then
+            $ECHO "Updating SELinux file contexts..."
+            ## Needed to update the filesystem contexts that depend on HOME_DIR, and wrongly assume /home
+            sudo semodule -e ns-core  2>&1 > /dev/null
+            sudo restorecon -R /Users 2>&1 > /dev/null
+        fi
     else
         HAS_AUDIO=`groups | grep audio`
         if [ "$HAS_AUDIO" = "" ]; then
@@ -136,33 +154,45 @@ setup_loginwindow()
         return
     fi
 
-    $ECHO "==============================================================================="
+    $ECHO "========================================================================="
     $ECHO "Configuring graphical login panel..."
-    $ECHO "==============================================================================="
-    $ECHO "You already have configured graphical login manager:"
-    $ECHO "    $DESC - $DM_UNIT"
+    $ECHO "========================================================================="
+    if [ -n "$DM_UNIT_FILE" ]; then
+        $ECHO "You already have configured graphical login manager:"
+        $ECHO "    $DESC - $DM_UNIT"
+        PROMPT="Replace it with NEXTSPACE login panel? [y/N]: "
+    else
+        $ECHO "No graphical login manager symlink was found."
+        PROMPT="Enable NEXTSPACE login panel? [y/N]: "
+    fi
 
-    $ECHO -n "Replace it with NEXTSPACE login panel? [y/N]: "
+        $ECHO_N "$PROMPT"
     read YN
     if [ "$YN" = "y" ]; then
-        sudo systemctl disable $DM_UNIT_FILE
+        if [ -n "$DM_UNIT_FILE" ]; then
+            sudo systemctl disable "$DM_UNIT_FILE"
+        fi
         sudo systemctl enable /usr/NextSpace/lib/systemd/loginwindow.service
         IS_CONFIGURED=1
     else
         $ECHO "Your answer is 'No'. Got it."
         $ECHO "You may later enable NEXTSPACE login panel with commands:"
-        $ECHO "    $ sudo systemctl disable $DM_UNIT_FILE"
+        if [ -n "$DM_UNIT_FILE" ]; then
+            $ECHO "    $ sudo systemctl disable $DM_UNIT_FILE"
+        fi
         $ECHO "    $ sudo systemctl enable /usr/NextSpace/lib/systemd/loginwindow.service"
     fi
     $ECHO "To return to your current setup after that use the following commands:"
     $ECHO "    $ sudo systemctl disable loginwindow.service"
-    $ECHO "    $ sudo systemctl enable $DM_UNIT"
+    if [ -n "$DM_UNIT" ]; then
+        $ECHO "    $ sudo systemctl enable $DM_UNIT"
+    fi
 
     if [ $IS_CONFIGURED = 1 ]; then
         # Default boot target
-        $ECHO -e -n "\e[33m"
-        $ECHO -n "Start graphical login panel on system boot? [y/N]: "
-        $ECHO -e -n "\e[0m"
+        $ECHO_N "\033[33m"
+        $ECHO_N "Start graphical login panel on system boot? [y/N]: "
+        $ECHO_N "\033[0m"
         read YN
         if [ "$YN" = "y" ]; then
             sudo systemctl set-default graphical.target
@@ -174,9 +204,9 @@ setup_loginwindow()
 
     if [ $IS_CONFIGURED = 1 ]; then
         # Start it now
-        $ECHO -e -n "\e[33m"
-        $ECHO -n "Do you want to start graphical login panel now? [y/N]: "
-        $ECHO -e -n "\e[0m"
+        $ECHO_N "\033[33m"
+        $ECHO_N "Do you want to start graphical login panel now? [y/N]: "
+        $ECHO_N "\033[0m"
         read YN
         if [ "$YN" = "y" ]; then
             sudo systemctl start loginwindow


### PR DESCRIPTION
…pendencies.

- Add automatic package install flags for apt, dnf and yum.
- Detect dnf/yum package manager dynamically for RPM-based systems.
- Normalize script output through global ECHO/ECHO_N helpers.
- Normalize separator frames and remove broken printf/echo -e output.
- Update libdispatch build to version 6.0.2.
- Relax libdispatch cast-function warning handling for newer clang.
- Fix CoreFoundation build/link issues by adding CFThreadSetName compatibility handling.
- Add and integrate 3_build_core.sh into source build sequence.
- Move core Linux resource installation into 3_build_core.sh.
- Prevent source tree from being mistaken for a binary distribution during install.
- Avoid overwriting built /Applications, /Library and /usr/NextSpace unless a binary tree is explicitly passed.
- Improve service checks for gdomap, gdnc, gpbs and Login panel.
- Add Fedora service executable permission/context preparation.
- Add Cairo/fontconfig/Xft/OpenGL dependencies for Debian back-end rendering.
- Build GNUstep back ART and Cairo backends explicitly with X11 server support.
- Update generated ZIP package with modified Packaging files.
- Add shared configure_debian_plymouth_boot helper (debian)
- Keep nextspace_install.sh focused on installation flow (debian)
- Configure Debian GRUB splash idempotently (debian)
- Run update-grub and update-initramfs only when GRUB config changes (debian)