### PR TITLE
Workspace: restore saved display layout by default

### DIFF
--- a/Applications/Workspace/Workspace_main.m
+++ b/Applications/Workspace/Workspace_main.m
@@ -142,7 +142,8 @@ int main(int argc, const char **argv)
   fprintf(stderr, "=== Starting Workspace ===\n");
   defs = [[OSEDefaults alloc] initDefaultsWithPath:NSUserDomainMask domain:@"Workspace"];
   workspace_q = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
-  if ([defs boolForKey:@"RestoreDisplayLayout"] != NO) {
+  if ([defs objectForKey:@"RestoreDisplayLayout"] == nil ||
+      [defs boolForKey:@"RestoreDisplayLayout"] == YES) {
     dispatch_sync(workspace_q, ^{
       // Restore display layout
       OSEScreen *screen = [OSEScreen sharedScreen];

--- a/OS/Linux/etc/skel/Library/Preferences/.NextSpace/Workspace
+++ b/OS/Linux/etc/skel/Library/Preferences/.NextSpace/Workspace
@@ -1,6 +1,7 @@
 {
     BrowserViewerColumnWidth = <*R150>;
     OpenConsoleAtStart = NO;
+    RestoreDisplayLayout = YES;
     RootShelfContents = {
     };
     RootViewerShelfSize = <*R76>;


### PR DESCRIPTION
The resolution chosen in Preferences->Display was correctly written to ~/Library/Preferences/.NextSpace/Displays-<hash>.config, but it was never reapplied on login. Workspace_main gated the restore on [defs boolForKey:@"RestoreDisplayLayout"] != NO, and since boolForKey: returns NO for an absent key, the condition was always false — the key is not set in any default config, so the layout was never restored and the display reverted to the X/RandR default after every reboot.

Treat a missing RestoreDisplayLayout key as YES, so the saved layout is restored unless the user explicitly disables it. Also ship the key in the skel Workspace defaults for discoverability on new installs. Restoring is safe: applyDisplayLayout: validates the layout first, and a hardware change yields a different config hash that falls back to the default layout.