### PR TITLE
Display: sync resolution popups after a revert, fix stale last-good

### DIFF
--- a/Applications/Preferences/Modules/Display/Display.m
+++ b/Applications/Preferences/Modules/Display/Display.m
@@ -457,6 +457,12 @@
   if ([[activeResolution objectForKey:OSEDisplayResolutionNameKey]
           isEqualToString:[oldResolution objectForKey:OSEDisplayResolutionNameKey]] != NO) {
     NSLog(@"%s: Resolution has been reverted to last good. Keep it!", __func__);
+    // The display was reverted (Revert pressed or countdown expired). The
+    // resolution popup still shows the rejected resolution, so sync it and the
+    // refresh-rate popup back to the now-active resolution.
+    [resolutionBtn selectItemWithTitle:[activeResolution objectForKey:OSEDisplayResolutionNameKey]];
+    [self fillRateButton];
+    [self updateRateButton];
     return;
   }
 
@@ -480,6 +486,10 @@
     }
   } else {
     NSLog(@"Keep current resoltuion.");
+    // Remember the kept resolution as the new "last good" so a subsequent
+    // revert returns here instead of to the resolution that was active before
+    // this change.
+    [lastGoodResolution setObject:activeResolution forKey:[selectedDisplay outputName]];
   }
   [alert release];
 }


### PR DESCRIPTION
Two related defects in the resolution-revert flow of the Display module:

1. When a resolution was rejected (Revert pressed or the countdown expired), the display reverted correctly but the resolution popup kept showing the rejected resolution. The popup selection was only ever set in monitorsListClicked:, and the revert path returned early without touching the UI. Reselect the active resolution and rebuild the refresh-rate popup in the "reverted to last good" branch.

2. Pressing Keep did not update lastGoodResolution, so it still held the resolution that was active when the monitor was selected. A later change followed by a revert would then jump back two steps instead of to the kept resolution. Record the active resolution as the new last-good when the user keeps it.